### PR TITLE
Fix navigation from table of contents

### DIFF
--- a/stories/kyoto2/01_passages/fushimi-inari.twee
+++ b/stories/kyoto2/01_passages/fushimi-inari.twee
@@ -42,8 +42,8 @@ The shrine features over 10,000 torii gates donated by individuals and businesse
 </div>
 
 <div class="navigation">
-<a class="nav-link" onclick="showCard(0)">← Table of Contents</a>
-<a class="nav-link" onclick="showCard(1)">← Golden Pavilion</a>
-<a class="nav-link" onclick="showCard(3)">Climb to Kiyomizu-dera →</a>
+<a class="nav-link" data-passage="Table of Contents">← Table of Contents</a>
+<a class="nav-link" data-passage="Kinkaku-ji">← Golden Pavilion</a>
+<a class="nav-link" data-passage="Kiyomizu-dera">Climb to Kiyomizu-dera →</a>
 </div>
 </div>

--- a/stories/kyoto2/01_passages/kinkaku-ji.twee
+++ b/stories/kyoto2/01_passages/kinkaku-ji.twee
@@ -42,8 +42,8 @@ The top two floors are completely covered in gold leaf, creating a stunning mirr
 </div>
 
 <div class="navigation">
-<a class="nav-link" onclick="showCard(0)">← Table of Contents</a>
-<a class="nav-link" onclick="showCard(2)">Visit Fushimi Inari →</a>
-<a class="nav-link" onclick="showCard(3)">Explore Kiyomizu-dera →</a>
+<a class="nav-link" data-passage="Table of Contents">← Table of Contents</a>
+<a class="nav-link" data-passage="Fushimi Inari Taisha">Visit Fushimi Inari →</a>
+<a class="nav-link" data-passage="Kiyomizu-dera">Explore Kiyomizu-dera →</a>
 </div>
 </div>

--- a/stories/kyoto2/01_passages/kiyomizu-dera.twee
+++ b/stories/kyoto2/01_passages/kiyomizu-dera.twee
@@ -42,8 +42,8 @@ The main hall's famous wooden veranda juts out 13 meters above the hillside, sup
 </div>
 
 <div class="navigation">
-<a class="nav-link" onclick="showCard(0)">← Table of Contents</a>
-<a class="nav-link" onclick="showCard(1)">← Golden Pavilion</a>
-<a class="nav-link" onclick="showCard(2)">← Thousand Torii Gates</a>
+<a class="nav-link" data-passage="Table of Contents">← Table of Contents</a>
+<a class="nav-link" data-passage="Kinkaku-ji">← Golden Pavilion</a>
+<a class="nav-link" data-passage="Fushimi Inari Taisha">← Thousand Torii Gates</a>
 </div>
 </div>

--- a/stories/kyoto2/01_passages/start.twee
+++ b/stories/kyoto2/01_passages/start.twee
@@ -5,20 +5,20 @@
 Explore three of Kyoto's most magnificent temples through these interactive cards. Each temple offers a unique glimpse into Japan's rich spiritual and architectural heritage.
 
 <div class="toc-grid">
-<div class="toc-item" onclick="showCard(1)">
+<a class="toc-item" data-passage="Kinkaku-ji">
 <h3>🏯 Kinkaku-ji (Golden Pavilion)</h3>
 <p>The iconic golden temple reflected in its serene pond</p>
-</div>
+</a>
 
-<div class="toc-item" onclick="showCard(2)">
+<a class="toc-item" data-passage="Fushimi Inari Taisha">
 <h3>⛩️ Fushimi Inari Taisha</h3>
 <p>Thousands of vermillion torii gates winding up the mountain</p>
-</div>
+</a>
 
-<div class="toc-item" onclick="showCard(3)">
+<a class="toc-item" data-passage="Kiyomizu-dera">
 <h3>🏛️ Kiyomizu-dera</h3>
 <p>The wooden temple with the famous cliff-side stage</p>
-</div>
+</a>
 </div>
 
 <div class="highlight">
@@ -26,6 +26,6 @@ Click on any temple above to begin your virtual journey through Kyoto's spiritua
 </div>
 
 <div class="navigation">
-<a class="nav-link" onclick="showCard(1)">Start with Golden Pavilion →</a>
+<a class="nav-link" data-passage="Kinkaku-ji">Start with Golden Pavilion →</a>
 </div>
 

--- a/stories/kyoto2/assets/scripts.js
+++ b/stories/kyoto2/assets/scripts.js
@@ -1,15 +1,3 @@
-function showCard(cardNumber) {
-    // Hide all cards
-    const cards = document.querySelectorAll('.card');
-    cards.forEach(card => card.classList.remove('active'));
-    
-    // Show selected card
-    const targetCard = document.getElementById(`card${cardNumber}`);
-    if (targetCard) {
-        targetCard.classList.add('active');
-    }
-}
-
 function toggleLocation(locationId) {
     const content = document.getElementById(locationId);
     const iconId = locationId.replace('location', 'icon');
@@ -29,9 +17,3 @@ function toggleLocation(locationId) {
         }
     }
 }
-
-// Initialize the first card as active when page loads
-document.addEventListener('DOMContentLoaded', function() {
-    // Show table of contents by default
-    showCard(0);
-});

--- a/stories/kyoto2/assets/styles.css
+++ b/stories/kyoto2/assets/styles.css
@@ -243,6 +243,9 @@ body {
     cursor: pointer;
     transition: all 0.3s ease;
     background: white;
+    text-decoration: none;
+    color: inherit;
+    display: block;
 }
 
 .toc-item:hover {


### PR DESCRIPTION
## Summary
- Link Kyoto Temple Guide table-of-contents items to their respective passages using `data-passage` anchors.
- Update navigation links throughout temple pages to use built-in SugarCube passage links.
- Remove unused card navigation script and style table items for anchor-based navigation.

## Testing
- `bash scripts/get_tweego.sh`
- `bash scripts/build.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c82b90f4f88330b9ada8cb7f80ba49