### PR TITLE
Fix table of contents links for Kyoto guide

### DIFF
--- a/stories/kyoto2/01_passages/start.twee
+++ b/stories/kyoto2/01_passages/start.twee
@@ -5,20 +5,20 @@
 Explore three of Kyoto's most magnificent temples through these interactive cards. Each temple offers a unique glimpse into Japan's rich spiritual and architectural heritage.
 
 <div class="toc-grid">
-<a class="toc-item" data-passage="Kinkaku-ji">
-<h3>🏯 Kinkaku-ji (Golden Pavilion)</h3>
+<div class="toc-item">
+<h3>[[🏯 Kinkaku-ji (Golden Pavilion)->Kinkaku-ji]]</h3>
 <p>The iconic golden temple reflected in its serene pond</p>
-</a>
+</div>
 
-<a class="toc-item" data-passage="Fushimi Inari Taisha">
-<h3>⛩️ Fushimi Inari Taisha</h3>
+<div class="toc-item">
+<h3>[[⛩️ Fushimi Inari Taisha->Fushimi Inari Taisha]]</h3>
 <p>Thousands of vermillion torii gates winding up the mountain</p>
-</a>
+</div>
 
-<a class="toc-item" data-passage="Kiyomizu-dera">
-<h3>🏛️ Kiyomizu-dera</h3>
+<div class="toc-item">
+<h3>[[🏛️ Kiyomizu-dera->Kiyomizu-dera]]</h3>
 <p>The wooden temple with the famous cliff-side stage</p>
-</a>
+</div>
 </div>
 
 <div class="highlight">

--- a/stories/kyoto2/assets/styles.css
+++ b/stories/kyoto2/assets/styles.css
@@ -240,11 +240,8 @@ body {
     border: 2px solid #8B4513;
     border-radius: 10px;
     padding: 20px;
-    cursor: pointer;
     transition: all 0.3s ease;
     background: white;
-    text-decoration: none;
-    color: inherit;
     display: block;
 }
 
@@ -258,6 +255,11 @@ body {
     color: #8B4513;
     margin: 0 0 10px 0;
     font-size: 1.3em;
+}
+
+.toc-item h3 a {
+    text-decoration: none;
+    color: inherit;
 }
 
 .toc-item p {


### PR DESCRIPTION
## Summary
- Ensure table of contents headings link to their passages using Twine syntax
- Update styles to match new DOM structure for toc links

## Testing
- `./scripts/build.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c8305f014483309bbaf660ec7ab2f5