### PR TITLE
chore(ci): deploy only from main

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           path: dist
   deploy:
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     needs: build
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
## Summary
- ensure Pages deploy runs only on pushes to main

## Testing
- `scripts/get_tweego.sh`
- `scripts/build.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c836697bcc8330adb553821351f95a