### PR TITLE
Improve service worker update flow

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,2 +1,83 @@
-// simple cache-first SW
-const CACHE='twine-japan-v1';self.addEventListener('install',e=>{e.waitUntil(caches.open(CACHE).then(c=>c.addAll(['./','./index.html','./manifest.webmanifest','./pwa/icon-192.png','./pwa/icon-512.png','./pwa/maskable-512.png'])))});self.addEventListener('activate',e=>{e.waitUntil(caches.keys().then(keys=>Promise.all(keys.filter(k=>k!==CACHE).map(k=>caches.delete(k)))))});self.addEventListener('fetch',e=>{e.respondWith(caches.match(e.request).then(r=>r||fetch(e.request).then(res=>{const c=res.clone(); if(e.request.method==='GET'){caches.open(CACHE).then(cc=>cc.put(e.request,c)).catch(()=>{});} return res;}).catch(()=>caches.match('./index.html'))))});
+const CACHE_VERSION = 'v2';
+const CACHE_NAME = `twine-japan-${CACHE_VERSION}`;
+const CORE_ASSETS = [
+  './',
+  './index.html',
+  './manifest.webmanifest',
+  './pwa/icon-192.png',
+  './pwa/icon-512.png',
+  './pwa/maskable-512.png',
+];
+
+self.addEventListener('install', (event) => {
+  self.skipWaiting();
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(CORE_ASSETS))
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    (async () => {
+      const keys = await caches.keys();
+      await Promise.all(
+        keys
+          .filter((key) => key !== CACHE_NAME)
+          .map((key) => caches.delete(key))
+      );
+
+      await self.clients.claim();
+      const clientList = await self.clients.matchAll({
+        type: 'window',
+        includeUncontrolled: true,
+      });
+
+      for (const client of clientList) {
+        if (!client.url) continue;
+        const url = new URL(client.url);
+        if (url.origin !== self.location.origin) continue;
+        if (typeof client.navigate === 'function') {
+          client.navigate(client.url).catch(() => {});
+        }
+      }
+    })()
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') {
+    return;
+  }
+
+  if (
+    event.request.cache === 'only-if-cached' &&
+    event.request.mode !== 'same-origin'
+  ) {
+    return;
+  }
+
+  event.respondWith(
+    (async () => {
+      try {
+        const networkResponse = await fetch(event.request);
+        const cache = await caches.open(CACHE_NAME);
+        cache.put(event.request, networkResponse.clone()).catch(() => {});
+        return networkResponse;
+      } catch (error) {
+        const cachedResponse = await caches.match(event.request);
+        if (cachedResponse) {
+          return cachedResponse;
+        }
+
+        if (event.request.mode === 'navigate') {
+          const fallback = await caches.match('./index.html');
+          if (fallback) {
+            return fallback;
+          }
+        }
+
+        throw error;
+      }
+    })()
+  );
+});


### PR DESCRIPTION
## Summary
- overhaul the service worker to use a versioned cache and clearer logic
- activate new service worker versions immediately and claim clients, forcing a one-time reload
- switch fetch handling to a network-first strategy with offline fallbacks so refreshed pages load the latest build

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c84ec683f08330a4db353d54abf8e7