### PR TITLE
Support latest story previews on Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,10 +3,10 @@ name: Build & Deploy Pages (Tweego + PWA)
 on:
   pull_request:
   push:
-    branches: [ main ]
+    branches: [ '**' ]
 
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 
@@ -15,6 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Determine story prefix
+        run: |
+          if [ "${GITHUB_REF_NAME}" != "main" ]; then
+            echo "STORY_PREFIX=latest_" >> "$GITHUB_ENV"
+          fi
       - name: Cache Tweego
         uses: actions/cache@v4
         with:
@@ -24,18 +29,45 @@ jobs:
         run: scripts/get_tweego.sh
       - name: Build
         run: scripts/build.sh
-      - name: Upload Pages Artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: dist
-  deploy:
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      - name: Prepare GitHub Pages branch
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          rm -rf gh-pages
+          if git ls-remote --exit-code origin gh-pages; then
+            git clone --depth 1 --branch gh-pages "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" gh-pages
+          else
+            git clone --depth 1 "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" gh-pages
+            cd gh-pages
+            git checkout --orphan gh-pages
+            git rm -rf . || true
+            find . -mindepth 1 -maxdepth 1 -not -name '.git' -exec rm -rf {} +
+            cd ..
+          fi
+      - name: Copy build output
+        if: github.event_name == 'push'
+        run: |
+          rsync -a dist/ gh-pages/
+          touch gh-pages/.nojekyll
+      - name: Regenerate index
+        if: github.event_name == 'push'
+        run: python3 scripts/update_pages_index.py gh-pages
+      - name: Commit and push
+        if: github.event_name == 'push'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          cd gh-pages
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          if [ -n "$(git status --porcelain)" ]; then
+            git add -A
+            git commit -m "Update pages for ${GITHUB_REF_NAME}"
+            git push origin gh-pages
+          else
+            echo "No changes to commit"
+          fi

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 BIN="${BIN:-.bin/tweego}"
 OUT="${OUT:-dist}"
+PREFIX="${STORY_PREFIX:-}"
 export TWEEGO_PATH="${TWEEGO_PATH:-formats}"
 rm -rf "$OUT"; mkdir -p "$OUT"
 build(){ deck="$1"; src="stories/${deck}";
@@ -9,7 +10,7 @@ if [[ ! -f "${src}/00_meta.twee" ]] || [[ ! -d "${src}/01_passages" ]]; then
   echo "Skipping ${deck}: missing story sources" >&2
   return
 fi
-outdir="${OUT}/${deck}"; mkdir -p "$outdir";
+outdir="${OUT}/${PREFIX}${deck}"; mkdir -p "$outdir";
 "$BIN" -l --head "shared/macros/widgets.js" --output "${outdir}/index.html" "${src}/00_meta.twee" "${src}/01_passages" shared/passages;
 [ -d "${src}/assets" ] && rsync -a "${src}/assets/" "${outdir}/assets/" || true;
 python3 - "$outdir/index.html" <<'PY'

--- a/scripts/update_pages_index.py
+++ b/scripts/update_pages_index.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+import html
+import sys
+from pathlib import Path
+
+ROOT = Path(sys.argv[1]) if len(sys.argv) > 1 else Path('dist')
+items = []
+for entry in sorted(ROOT.iterdir()):
+    if not entry.is_dir():
+        continue
+    index_file = entry / 'index.html'
+    if not index_file.exists():
+        continue
+    name = entry.name
+    items.append(f"<li><a href='./{html.escape(name)}/index.html'>{html.escape(name)}</a></li>")
+page = """<!doctype html><html><head><meta charset='utf-8'><meta name='viewport' content='width=device-width, initial-scale=1'>
+<link rel='manifest' href='./manifest.webmanifest'><link rel='apple-touch-icon' href='./pwa/icon-192.png'>
+<title>Twine Decks - Japan</title><style>body{font-family:-apple-system,system-ui,Roboto,Arial,sans-serif;max-width:900px;margin:2rem auto;padding:1rem}li{margin:.5rem 0}</style>
+</head><body><h1>Twine Decks - Japan</h1><ul>""" + "\n".join(items) + """</ul><script>if('serviceWorker' in navigator){window.addEventListener('load',()=>navigator.serviceWorker.register('./sw.js').catch(()=>{}));}</script></body></html>"""
+ROOT.joinpath('index.html').write_text(page, encoding='utf-8')
+print(f'Root index written to {ROOT / "index.html"}')


### PR DESCRIPTION
## Summary
- allow the story build to add an optional prefix so branches can publish `latest_` decks
- add a helper to rebuild the GitHub Pages index from the generated folders
- push build outputs into the `gh-pages` branch so non-main branches publish alongside main

## Testing
- scripts/get_tweego.sh
- ./scripts/build.sh
- STORY_PREFIX=latest_ ./scripts/build.sh
- python3 scripts/update_pages_index.py dist

------
https://chatgpt.com/codex/tasks/task_e_68ca4cd819988330a173d8aa235abf78