### PR TITLE
Add GitHub Pages deployment step

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -13,6 +13,9 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
       - name: Determine story prefix
@@ -71,3 +74,21 @@ jobs:
           else
             echo "No changes to commit"
           fi
+      - name: Prepare deployment artifact
+        if: github.event_name == 'push'
+        run: |
+          rm -rf gh-pages-public
+          mkdir -p gh-pages-public
+          rsync -a --delete --exclude '.git' gh-pages/ gh-pages-public/
+      - name: Upload GitHub Pages artifact
+        if: github.event_name == 'push'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: gh-pages-public
+      - name: Deploy to GitHub Pages
+        if: github.event_name == 'push'
+        id: deploy
+        uses: actions/deploy-pages@v4
+      - name: Display deployment URL
+        if: github.event_name == 'push'
+        run: echo "GitHub Pages URL: ${{ steps.deploy.outputs.page_url }}"


### PR DESCRIPTION
## Summary
- configure the workflow environment to expose the deployment URL for the GitHub Pages job
- package the gh-pages branch contents for deployment and upload them as a Pages artifact
- deploy the artifact to GitHub Pages and print the published URL in the workflow log

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68ca50af2b3c8330aa1b1a251cab9125