### PR TITLE
Fix Pages workflow run command syntax

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -91,4 +91,5 @@ jobs:
         uses: actions/deploy-pages@v4
       - name: Display deployment URL
         if: github.event_name == 'push'
-        run: echo "GitHub Pages URL: ${{ steps.deploy.outputs.page_url }}"
+        run: |
+          echo "GitHub Pages URL: ${{ steps.deploy.outputs.page_url }}"


### PR DESCRIPTION
## Summary
- fix the GitHub Pages deployment job to use a multiline run command for the display step

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68ca51dfcb8883308a5cac1a1a6b1b28