### PR TITLE
Adjust GitHub Pages workflows

### DIFF
--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -1,0 +1,41 @@
+name: Deploy GitHub Pages from Branch
+
+on:
+  push:
+    branches: [ gh-pages ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "gh-pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v4
+      - name: Prepare deployment artifact
+        run: |
+          rm -rf public
+          mkdir -p public
+          rsync -a --delete --exclude '.git' ./ public/
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: public
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,4 +1,4 @@
-name: Build & Deploy Pages (Tweego + PWA)
+name: Build Pages (Tweego + PWA)
 
 on:
   pull_request:
@@ -13,15 +13,12 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deploy.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
       - name: Determine story prefix
         run: |
           if [ "${GITHUB_REF_NAME}" != "main" ]; then
-            echo "STORY_PREFIX=latest_" >> "$GITHUB_ENV"
+            echo "STORY_PREFIX=z_staging_" >> "$GITHUB_ENV"
           fi
       - name: Cache Tweego
         uses: actions/cache@v4
@@ -74,21 +71,3 @@ jobs:
           else
             echo "No changes to commit"
           fi
-      - name: Prepare deployment artifact
-        if: github.event_name == 'push'
-        run: |
-          rm -rf gh-pages-public
-          mkdir -p gh-pages-public
-          rsync -a --delete --exclude '.git' gh-pages/ gh-pages-public/
-      - name: Upload GitHub Pages artifact
-        if: github.event_name == 'push'
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: gh-pages-public
-      - name: Deploy to GitHub Pages
-        if: github.event_name == 'push'
-        id: deploy
-        uses: actions/deploy-pages@v4
-      - name: Display deployment URL
-        if: github.event_name == 'push'
-        run: echo "GitHub Pages URL: ${{ steps.deploy.outputs.page_url }}"


### PR DESCRIPTION
## Summary
- update the main build workflow to use the z_staging_ prefix for non-main builds and only push updates to the gh-pages branch
- add a dedicated workflow that deploys the gh-pages branch to GitHub Pages when it changes

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ca53c4aad08330b336477e1821b5fb