### PR TITLE
Adjust Nikko story spacing

### DIFF
--- a/stories/nikko1/assets/styles.css
+++ b/stories/nikko1/assets/styles.css
@@ -18,7 +18,7 @@ body {
     max-width: 800px !important;
     margin: 0 auto !important;
     background: white !important;
-    padding: 40px 50px !important;
+    padding: 24px 32px !important;
     border-radius: 15px !important;
     box-shadow: 0 10px 30px rgba(0,0,0,0.2) !important;
 }
@@ -36,8 +36,8 @@ h1, #passages h1, tw-passage h1, .passage h1 {
 h2, #passages h2, tw-passage h2, .passage h2 {
     color: #1e3a8a !important;
     font-size: 1.5em !important;
-    margin: 20px 0 10px 0 !important;
-    padding: 0 0 8px 0 !important;
+    margin: 12px 0 6px 0 !important;
+    padding: 0 0 6px 0 !important;
     border-bottom: 2px solid #1e3a8a !important;
     border-top: none !important;
     text-indent: 0 !important;
@@ -46,7 +46,7 @@ h2, #passages h2, tw-passage h2, .passage h2 {
 
 h3, #passages h3, tw-passage h3, .passage h3 {
     color: #2E8B57 !important;
-    margin: 0 0 10px 0 !important;
+    margin: 6px 0 6px 0 !important;
     padding: 0 !important;
     font-size: 1.3em !important;
     text-indent: 0 !important;
@@ -54,7 +54,7 @@ h3, #passages h3, tw-passage h3, .passage h3 {
 
 /* Paragraph spacing - CRITICAL FIX */
 p, #passages p, tw-passage p, .passage p {
-    margin: 3px 0 !important;
+    margin: 0 0 10px 0 !important;
     padding: 0 !important;
     line-height: 1.6 !important;
     text-indent: 0 !important;
@@ -79,13 +79,13 @@ ul, ol, li {
     box-shadow: 0 10px 30px rgba(0,0,0,0.2);
     max-width: 650px;
     width: 95%;
-    padding: 40px 55px;
+    padding: 24px 32px;
     display: none;
     position: relative;
     border: 3px solid #2E8B57;
     max-height: 90vh;
     overflow-y: auto;
-    margin: 20px auto;
+    margin: 12px auto;
     box-sizing: border-box;
 }
 
@@ -146,7 +146,7 @@ ul, ol, li {
 }
 
 .card-content p {
-    margin: 3px 0 !important;
+    margin: 0 0 10px 0 !important;
     padding: 0 !important;
 }
 


### PR DESCRIPTION
## Summary
- reduce the `#passages` and card padding so content sits closer to the green border
- tighten heading and paragraph margins to remove the blank-line appearance at the top of sections

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca5699d3b48330965674caeae7964f