### PR TITLE
Add authoring guide for Twine travel sites

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ This repository houses multiple travel-guide microsites built with **Twine** (vi
   - Create a “Table of Contents” passage that acts as the starting entry, categorizing content (e.g., Attractions, Hotels, Transport, Hikes) into grid cards that link to individual passages.
   - Within passages, wrap the main content in `.card` markup with `card-number`, `card-header`, `card-content`, and `.navigation` links, mirroring the Nikko site.
   - Use `.highlight` blocks for key callouts (hours, fees, fun facts) and the collapsible `.location-section` for address/mapping information. These styles and behaviors are defined in `assets/styles.css` and `assets/scripts.js` respectively.
-  - Provide navigation links back to the Table of Contents and onward to related attractions to maintain traversal flow.
+  - Provide navigation links back to the Table of Contents and onward to related cards to maintain traversal flow.
 - Store deck-specific imagery under `assets/images/` and reference them using relative paths inside passages. When practical, prefer checked-in assets over hotlinking external images.
 
 ## Styling and scripting conventions
@@ -28,14 +28,15 @@ This repository houses multiple travel-guide microsites built with **Twine** (vi
 - `stories/nikko1/assets/scripts.js` exposes `toggleLocation()` for collapsing and expanding location details. If you add new interactive helpers, place them in `assets/scripts.js` and ensure `00_meta.twee` appends the script tag using the same pattern (`Story JavaScript` passage injecting `assets/scripts.js`).
 
 ## Content structure expectations (based on `nikko1`)
-- Group attractions into logical sections (Attractions, Hotels, Transport, Hikes, etc.) on the Table of Contents. Each section’s cards should provide a short description beneath the link to encourage exploration.
-- Individual attraction passages typically include:
+- Group cards into logical sections (Attractions, Hotels, Transport, Hikes, etc.) on the Table of Contents. Each section’s cards should provide a short description beneath the link to encourage exploration.
+- Individual cards typically include:
   - Card header with Japanese and English titles plus a sequential `card-number`.
   - Hero imagery (`.temple-image`) followed by collapsible location info (address in Japanese and English plus Google Maps link).
   - One or more `.highlight` callouts emphasizing visiting tips, hours, admission fees, or notable facts.
   - Narrative paragraphs giving historical context, cultural insights, and travel guidance.
   - Outbound resources (e.g., Wikipedia link) styled with `.wikipedia-link`.
   - `.navigation` links that weave the passage back into the broader itinerary.
-- Hike passages follow the same template but focus highlights on trail stats, elevation, and required logistics; transport passages emphasize schedules and connectivity.
+- Hike passages follow the same template but focus highlights on trail stats, elevation, and required logistics, and provide a link to another site like alltrails.com for more info
+- Transport passages emphasize schedules and connectivity.
 
 By following these patterns you can introduce additional regional guides without interfering with existing ones. Always run the build script before committing so that automated workflows—and eventual GitHub Pages deployments—remain in sync with your changes.


### PR DESCRIPTION
## Summary
- add a root-level authoring guide for contributors building new Twine microsites
- document the repository layout, build pipeline, and GitHub Actions support
- capture the nikko1 content structure conventions (cards, highlights, locations) for reuse across new destinations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d840459c208330bbd18e84947a13eb