### PR TITLE
Add Osaka travel guide Twine story

### DIFF
--- a/stories/osaka1/00_meta.twee
+++ b/stories/osaka1/00_meta.twee
@@ -1,0 +1,20 @@
+:: StoryTitle
+Osaka Travel Guide
+
+:: StoryData
+{
+  "ifid": "968DD69B-8F2D-4795-B245-4A175B662155",
+  "format": "SugarCube",
+  "format-version": "2.36.1",
+  "start": "Table of Contents",
+  "zoom": 1
+}
+
+:: StoryStylesheet [stylesheet]
+@import url("./assets/styles.css");
+
+:: Story JavaScript [script]
+// Load functional JavaScript for location toggle
+var script = document.createElement('script');
+script.src = 'assets/scripts.js';
+document.head.appendChild(script);

--- a/stories/osaka1/01_passages/dotonbori-and-shinsaibashi-arcade.twee
+++ b/stories/osaka1/01_passages/dotonbori-and-shinsaibashi-arcade.twee
@@ -1,0 +1,52 @@
+:: Dotonbori & Shinsaibashi Arcade
+<div class="card active" id="card1">
+<div class="card-number">1</div>
+<div class="card-header">
+<h1 class="card-title">道頓堀と心斎橋筋商店街</h1>
+<h2 class="card-subtitle">Dotonbori &amp; Shinsaibashi Arcade</h2>
+</div>
+
+<div class="card-content">
+<img src="https://upload.wikimedia.org/wikipedia/commons/2/2a/Dotonbori_at_night.jpg" alt="Dotonbori canal at night" class="temple-image">
+
+<div class="location-section">
+<div class="location-toggle" onclick="toggleLocation('location1')">
+<div class="location-label">📍 Location</div>
+<div class="toggle-icon" id="icon1">+</div>
+</div>
+<div class="location-content" id="location1">
+<div class="address">
+<span class="address-label">Japanese:</span>
+<span class="address-text">〒542-0085 大阪府大阪市中央区道頓堀・心斎橋筋</span>
+</div>
+<div class="address">
+<span class="address-label">English:</span>
+<span class="address-text">Dotonbori &amp; Shinsaibashi-suji, Chuo Ward, Osaka 542-0085, Japan</span>
+</div>
+<a href="https://www.google.com/maps/search/?api=1&query=Dotonbori+Osaka" target="_blank" class="maps-link">🗺️ Open in Google Maps</a>
+</div>
+</div>
+
+<div class="highlight">
+<strong>Walk length:</strong> 1.6 km canal-to-arcade loop<br>
+<strong>Nearest station:</strong> Namba Station (Midosuji, Yotsubashi, Sennichimae lines) or Shinsaibashi Station
+</div>
+
+<p>Start at Ebisu Bridge for the iconic view of the Glico neon runner reflecting on the Dotonbori canal. Street performers, takoyaki vendors, and river cruise announcers set the tone for Osaka's exuberant entertainment district.</p>
+
+<p>Follow the boardwalk east to Hozenji Yokocho, a lantern-lit alley anchored by the moss-covered Hozenji Fudo statue. Slip a coin in the basin, splash the deity with ladles of water like locals do, then step into one of the udon or okonomiyaki counters lining the stone-paved lane.</p>
+
+<div class="highlight">
+<strong>Food crawl tip:</strong> Alternate sweet and savory bites—charcoal-grilled crab legs, melonpan ice cream, kushi-katsu skewers, and fluffy ricotta pancakes are all within a five-minute walk.</div>
+
+<p>Continue north via Midosuji's ginkgo-lined boulevard to the covered Shinsaibashi-suji arcade. This 600-meter shopping tunnel blends global flagships, long-running kimono drapers, sneaker boutiques, and character goods stores. Side streets westward spill into Amerikamura's murals and vintage shops if you crave more youth culture.</p>
+
+<a href="https://osaka-info.jp/en/areas/minami/dotonbori/" target="_blank" class="wikipedia-link">🌐 Osaka Convention &amp; Tourism Bureau neighborhood guide</a>
+</div>
+
+<div class="navigation">
+<a class="nav-link" data-passage="Table of Contents">← Table of Contents</a>
+<a class="nav-link" data-passage="Shinsekai &amp; Tsutenkaku Loop">Next: Shinsekai &amp; Tsutenkaku →</a>
+</div>
+
+</div>

--- a/stories/osaka1/01_passages/kix-to-omo-kansai-airport-hotel.twee
+++ b/stories/osaka1/01_passages/kix-to-omo-kansai-airport-hotel.twee
@@ -1,0 +1,65 @@
+:: KIX to OMO Kansai Airport Hotel
+<div class="card active" id="card1">
+<div class="card-number">5</div>
+<div class="card-header">
+<h1 class="card-title">関西空港からOMO関西空港</h1>
+<h2 class="card-subtitle">Getting to OMO Kansai Airport by Hoshino Resorts</h2>
+</div>
+
+<div class="card-content">
+<img src="https://upload.wikimedia.org/wikipedia/commons/4/4c/Kansai_Airport_Station_2018.jpg" alt="Kansai Airport station platforms" class="temple-image">
+
+<div class="location-section">
+<div class="location-toggle" onclick="toggleLocation('location5')">
+<div class="location-label">📍 Hotel Contact</div>
+<div class="toggle-icon" id="icon5">+</div>
+</div>
+<div class="location-content" id="location5">
+<div class="address">
+<span class="address-label">Name:</span>
+<span class="address-text">OMO Kansai Airport by Hoshino Resorts</span>
+</div>
+<div class="address">
+<span class="address-label">Phone:</span>
+<span class="address-text">+81-50-3786-1144</span>
+</div>
+<div class="address">
+<span class="address-label">Email:</span>
+<span class="address-text"><a href="mailto:kansaiairport@omo-hotels.com">kansaiairport@omo-hotels.com</a></span>
+</div>
+<a href="https://hoshinoresorts.com/en/hotels/omokansaiairport/" target="_blank" class="maps-link">🌐 Official hotel website</a>
+</div>
+</div>
+
+<div class="highlight">
+<strong>Hotel location:</strong> Within Aeroplaza, the commercial complex opposite Terminal 1 at KIX<br>
+<strong>Check-in:</strong> 15:00 / <strong>Check-out:</strong> 11:00
+</div>
+
+<p>OMO Kansai Airport occupies several floors of the Aeroplaza, the mixed-use building connected to Kansai International Airport's Terminals 1 and 2 via free shuttle buses and an enclosed pedestrian bridge. Once you arrive at KIX, you do not need to leave the island to reach the hotel.</p>
+
+<h3>Fastest daytime route (Haruka or Limited Express)</h3>
+<p>Ride the JR Kansai-Airport Rapid or Limited Express Haruka one stop from Kansai Airport Station to <strong>Rinku Town Station</strong> (5 minutes) if you want to pick up supplies at the Rinku Premium Outlets before checking in. Otherwise remain on the train: the very next stop back at Kansai Airport Station deposits you directly beneath Aeroplaza. Follow signs for Aeroplaza / Hotels and take the escalator to level 2 for the lobby.</p>
+
+<div class="highlight">
+<strong>Tip:</strong> ICOCA and other IC cards work on all JR and Nankai trains at KIX. Scan out at Kansai Airport Station to exit toward the hotel.
+</div>
+
+<h3>Late-night arrival (Nankai Line)</h3>
+<p>If you land after the JR services finish (~23:30), the Nankai Line's final <strong>Rapi:t</strong> limited express from Namba still returns to Kansai Airport around 23:40. The station concourse remains open, and the covered walkway to Aeroplaza is lit 24 hours, allowing a smooth transfer even past midnight.</p>
+
+<h3>Luggage-friendly shuttle</h3>
+<p>Free <strong>Aeroplaza Shuttle</strong> buses loop between Terminal 1 (outside Arrival Hall 1F), Terminal 2 (bus stop 1), and Aeroplaza every 5–10 minutes from early morning until late night. Tell the driver "OMO hotel" and alight at the Aeroplaza stop. Elevators just inside the entrance lead to the hotel reception.</p>
+
+<h3>Driving or taxi</h3>
+<p>The hotel does not operate a private car park. Use KIX's <strong>P1</strong> or <strong>P2</strong> short-term parking connected to Aeroplaza; guests receive discounted rates by validating tickets at reception. A taxi from the Terminal 1 curb to Aeroplaza costs around ¥680 and takes under five minutes.</p>
+
+<a href="https://www.kansai-airport.or.jp/en/access/bus" target="_blank" class="wikipedia-link">🚌 Kansai International Airport ground transport details</a>
+</div>
+
+<div class="navigation">
+<a class="nav-link" data-passage="Table of Contents">← Table of Contents</a>
+<a class="nav-link" data-passage="Dotonbori &amp; Shinsaibashi Arcade">Back to Neighborhoods →</a>
+</div>
+
+</div>

--- a/stories/osaka1/01_passages/nakanoshima-culture-walk.twee
+++ b/stories/osaka1/01_passages/nakanoshima-culture-walk.twee
@@ -1,0 +1,52 @@
+:: Nakanoshima Culture Walk
+<div class="card active" id="card1">
+<div class="card-number">4</div>
+<div class="card-header">
+<h1 class="card-title">中之島カルチャー散策</h1>
+<h2 class="card-subtitle">Nakanoshima Culture Walk</h2>
+</div>
+
+<div class="card-content">
+<img src="https://upload.wikimedia.org/wikipedia/commons/4/4c/Nakanoshima_Park_Rose_Garden.jpg" alt="Nakanoshima riverside park" class="temple-image">
+
+<div class="location-section">
+<div class="location-toggle" onclick="toggleLocation('location4')">
+<div class="location-label">📍 Location</div>
+<div class="toggle-icon" id="icon4">+</div>
+</div>
+<div class="location-content" id="location4">
+<div class="address">
+<span class="address-label">Japanese:</span>
+<span class="address-text">〒530-0005 大阪府大阪市北区中之島</span>
+</div>
+<div class="address">
+<span class="address-label">English:</span>
+<span class="address-text">Nakanoshima, Kita Ward, Osaka 530-0005, Japan</span>
+</div>
+<a href="https://www.google.com/maps/search/?api=1&query=Nakanoshima+Park+Osaka" target="_blank" class="maps-link">🗺️ Open in Google Maps</a>
+</div>
+</div>
+
+<div class="highlight">
+<strong>Walk length:</strong> 2 km riverfront promenade<br>
+<strong>Nearest station:</strong> Yodoyabashi Station (Midosuji Line), Naniwabashi Station (Keihan Nakanoshima Line)
+</div>
+
+<p>Nakanoshima is a slender island sandwiched between the Dojima and Tosabori Rivers. Civic landmarks and manicured parks make it ideal for a cultural stroll that balances architecture, art, and river breezes.</p>
+
+<p>Begin at the Osaka City Central Public Hall, a 1918 Neo-Renaissance masterpiece built during the Kansai industrial boom. Free exhibits explain how stockbroker donations funded the grand auditorium. Cross the plaza to the Osaka Prefectural Nakanoshima Library to admire its Corinthian columns and quiet reading room.</p>
+
+<div class="highlight">
+<strong>Art stop:</strong> The Nakanoshima Museum of Art showcases mid-century Gutai works, Yayoi Kusama pieces, and rotating design exhibits. Book timed tickets online on busy weekends.</div>
+
+<p>Continue west through Nakanoshima Park's rose garden, especially fragrant in May and October. Picnic on the lawns while river cruises glide past, then cap the walk at the renovated Festival Tower, where you can catch an evening performance at the Festival Hall or sip cocktails at the observation lounge overlooking the lights of Umeda.</p>
+
+<a href="https://osaka-info.jp/en/areas/kita/nakanoshima/" target="_blank" class="wikipedia-link">🌐 Osaka Info: Nakanoshima highlights</a>
+</div>
+
+<div class="navigation">
+<a class="nav-link" data-passage="Table of Contents">← Table of Contents</a>
+<a class="nav-link" data-passage="KIX to OMO Kansai Airport Hotel">Transport: KIX to OMO →</a>
+</div>
+
+</div>

--- a/stories/osaka1/01_passages/nakazakicho-retro-lanes.twee
+++ b/stories/osaka1/01_passages/nakazakicho-retro-lanes.twee
@@ -1,0 +1,52 @@
+:: Nakazakicho Retro Lanes
+<div class="card active" id="card1">
+<div class="card-number">3</div>
+<div class="card-header">
+<h1 class="card-title">中崎町レトロ路地</h1>
+<h2 class="card-subtitle">Nakazakicho Retro Lanes</h2>
+</div>
+
+<div class="card-content">
+<img src="https://upload.wikimedia.org/wikipedia/commons/2/29/Nakazakicho_osaka.jpg" alt="Nakazakicho alley with cafes" class="temple-image">
+
+<div class="location-section">
+<div class="location-toggle" onclick="toggleLocation('location3')">
+<div class="location-label">📍 Location</div>
+<div class="toggle-icon" id="icon3">+</div>
+</div>
+<div class="location-content" id="location3">
+<div class="address">
+<span class="address-label">Japanese:</span>
+<span class="address-text">〒530-0015 大阪府大阪市北区中崎西・中崎</span>
+</div>
+<div class="address">
+<span class="address-label">English:</span>
+<span class="address-text">Nakazaki, Kita Ward, Osaka 530-0015, Japan</span>
+</div>
+<a href="https://www.google.com/maps/search/?api=1&query=Nakazakicho+Osaka" target="_blank" class="maps-link">🗺️ Open in Google Maps</a>
+</div>
+</div>
+
+<div class="highlight">
+<strong>Walk length:</strong> 1 km meander through backstreets<br>
+<strong>Nearest station:</strong> Nakazakicho Station (Tanimachi Line) or Umeda Station (10-minute walk)
+</div>
+
+<p>Nakazakicho survived wartime air raids, leaving clusters of pre-war wooden nagaya row houses intact. In the 2000s creatives began converting them into ateliers, select shops, and photogenic cafés, creating a gentle alternative to the skyscrapers of nearby Umeda.</p>
+
+<p>Start at Nakazakicho Station and wander north to Café Arabiq for siphon coffee, then browse used books and zines at Salon de Amanto—a pioneering art space. Many shops open around 11:00, so aim for a late-morning visit when shutters roll up and the scent of fresh-baked taiyaki fills the alleys.</p>
+
+<div class="highlight">
+<strong>Heritage insight:</strong> Spot the city-designated "Nagaya Terraces" plaques explaining how the row houses were raised in the Taisho era for textile mill workers.</div>
+
+<p>Head west toward the Nakazakicho "Mori no Ichi" mini market, held on select weekends with handmade accessories, kimono remakes, and small-batch pastries. Finish at the elevated Hankyu Railway viaduct, where murals and pop-up bars animate the arches by sunset.</p>
+
+<a href="https://osaka-info.jp/en/areas/kita/nakazakicho/" target="_blank" class="wikipedia-link">🌐 Osaka Info overview of Nakazakicho</a>
+</div>
+
+<div class="navigation">
+<a class="nav-link" data-passage="Table of Contents">← Table of Contents</a>
+<a class="nav-link" data-passage="Nakanoshima Culture Walk">Stroll Nakanoshima →</a>
+</div>
+
+</div>

--- a/stories/osaka1/01_passages/shinsekai-and-tsutenkaku-loop.twee
+++ b/stories/osaka1/01_passages/shinsekai-and-tsutenkaku-loop.twee
@@ -1,0 +1,52 @@
+:: Shinsekai & Tsutenkaku Loop
+<div class="card active" id="card1">
+<div class="card-number">2</div>
+<div class="card-header">
+<h1 class="card-title">新世界と通天閣散策</h1>
+<h2 class="card-subtitle">Shinsekai &amp; Tsutenkaku Loop</h2>
+</div>
+
+<div class="card-content">
+<img src="https://upload.wikimedia.org/wikipedia/commons/4/4e/Tsutenkaku_Tower_2014.jpg" alt="Tsutenkaku tower at dusk" class="temple-image">
+
+<div class="location-section">
+<div class="location-toggle" onclick="toggleLocation('location2')">
+<div class="location-label">📍 Location</div>
+<div class="toggle-icon" id="icon2">+</div>
+</div>
+<div class="location-content" id="location2">
+<div class="address">
+<span class="address-label">Japanese:</span>
+<span class="address-text">〒556-0002 大阪府大阪市浪速区恵美須東・新世界</span>
+</div>
+<div class="address">
+<span class="address-label">English:</span>
+<span class="address-text">Shinsekai, Ebisuhigashi, Naniwa Ward, Osaka 556-0002, Japan</span>
+</div>
+<a href="https://www.google.com/maps/search/?api=1&query=Shinsekai+Tsutenkaku" target="_blank" class="maps-link">🗺️ Open in Google Maps</a>
+</div>
+</div>
+
+<div class="highlight">
+<strong>Walk length:</strong> 1.2 km retro circuit<br>
+<strong>Nearest station:</strong> Ebisucho Station (Sakaisuji Line) or Dobutsuen-mae Station
+</div>
+
+<p>Shinsekai debuted in 1912 as a futuristic entertainment quarter inspired by Paris and Coney Island. Today its neon signboards, paper lanterns, and Showa-era arcades make it one of Osaka's most atmospheric evening walks.</p>
+
+<p>Start beneath the 103-meter Tsutenkaku tower—nicknamed the "Tower Reaching Heaven." Ride the retro elevator to the observation deck to spot Abeno Harukas to the south and Osaka Bay to the west. Inside the tower, rub the foot of Billiken, the quirky good-luck deity adopted by locals.</p>
+
+<div class="highlight">
+<strong>Snack like a local:</strong> Kushikatsu Daruma and Yaekatsu each fry golden skewers of beef, lotus root, and quail eggs. Remember the house rule—no double-dipping into the communal sauce vats.</div>
+
+<p>Continue along Jan-Jan Yokocho, a narrow lane lined with pinball parlors, ticket shops, and izakaya grilling doteyaki beef tendon. Loop south to Tennoji Zoo's Art Deco gates, then detour into Spa World if you want a themed super sento soak. As night deepens, Tsutenkaku's LED panels change colors to forecast the next day's weather.</p>
+
+<a href="https://osaka-info.jp/en/spot/tsutenkaku-tower/" target="_blank" class="wikipedia-link">🌐 Official Tsutenkaku visitor information</a>
+</div>
+
+<div class="navigation">
+<a class="nav-link" data-passage="Table of Contents">← Table of Contents</a>
+<a class="nav-link" data-passage="Nakazakicho Retro Lanes">Explore Nakazakicho →</a>
+</div>
+
+</div>

--- a/stories/osaka1/01_passages/start.twee
+++ b/stories/osaka1/01_passages/start.twee
@@ -1,0 +1,51 @@
+:: StoryConfig [init]
+<<run Config.passages.nobr = true>>
+:: Table of Contents
+<div class="card active" id="card1">
+<div class="card-number">0</div>
+<div class="card-header">
+<h1 class="card-title">大阪</h1>
+<h1 class="card-title">Osaka City Guide</h1>
+</div>
+
+<p>Osaka blends mercantile grit with Kansai warmth. Compact neighborhoods brim with neon canals, retro arcades, riverfront museums, and laid-back café culture. This deck spotlights four districts that are easy to explore on foot plus essential airport transfer tips.</p>
+
+<h2>Neighborhoods</h2>
+
+<div class="toc-grid">
+<div class="toc-item">
+<h3>[[🌃 Dotonbori &amp; Shinsaibashi Arcade->Dotonbori &amp; Shinsaibashi Arcade]]</h3>
+<p>Follow the canal from Ebisu Bridge through Osaka's most famous nightlife promenade.</p>
+</div>
+
+<div class="toc-item">
+<h3>[[🎭 Shinsekai &amp; Tsutenkaku Loop->Shinsekai &amp; Tsutenkaku Loop]]</h3>
+<p>Retro Osaka icons, kushikatsu eateries, and Showa-era charm beneath the tower lights.</p>
+</div>
+
+<div class="toc-item">
+<h3>[[☕ Nakazakicho Retro Lanes->Nakazakicho Retro Lanes]]</h3>
+<p>Converted machiya houses, indie galleries, and kissaten cafés north of Umeda.</p>
+</div>
+
+<div class="toc-item">
+<h3>[[🏞️ Nakanoshima Culture Walk->Nakanoshima Culture Walk]]</h3>
+<p>Art museums and riverside greenways between Osaka's two major rivers.</p>
+</div>
+</div>
+
+<h2>Transport</h2>
+
+<div class="toc-grid">
+<div class="toc-item">
+<h3>[[✈️ KIX to OMO Kansai Airport Hotel->KIX to OMO Kansai Airport Hotel]]</h3>
+<p>Compare trains, shuttle buses, and late-night options to reach the on-airport stay.</p>
+</div>
+</div>
+
+<div class="navigation">
+<a class="nav-link" data-passage="Dotonbori &amp; Shinsaibashi Arcade">Start with Dotonbori →</a>
+</div>
+
+:: PassageFooter
+<p class="footer">2025-09-18 Ken Novak</p>

--- a/stories/osaka1/assets/scripts.js
+++ b/stories/osaka1/assets/scripts.js
@@ -1,0 +1,19 @@
+function toggleLocation(locationId) {
+    const content = document.getElementById(locationId);
+    const iconId = locationId.replace('location', 'icon');
+    const icon = document.getElementById(iconId);
+    
+    if (content && icon) {
+        if (content.classList.contains('expanded')) {
+            // Collapse
+            content.classList.remove('expanded');
+            icon.textContent = '+';
+            icon.style.transform = 'rotate(0deg)';
+        } else {
+            // Expand
+            content.classList.add('expanded');
+            icon.textContent = '−';
+            icon.style.transform = 'rotate(180deg)';
+        }
+    }
+}

--- a/stories/osaka1/assets/styles.css
+++ b/stories/osaka1/assets/styles.css
@@ -1,0 +1,462 @@
+body {
+    font-family: 'Georgia', serif !important;
+    background: linear-gradient(135deg, #f0f8ff 0%, #e6f3ff 100%);
+    margin: 0;
+    padding: 4px 10px 10px 10px;
+    min-height: 100vh;
+    line-height: 1.4 !important;
+}
+
+/* AGGRESSIVE RESET - Override SugarCube defaults */
+#passages, #passages *, tw-passage, tw-passage * {
+    margin: 0 !important;
+    padding: 0 !important;
+}
+
+/* Main passage container */
+#passages {
+    max-width: 800px !important;
+    margin: 0 auto !important;
+    background: white !important;
+    padding: 40px 50px !important;
+    border-radius: 15px !important;
+    box-shadow: 0 10px 30px rgba(0,0,0,0.2) !important;
+}
+
+/* Main title colors - simple approach */
+h1, #passages h1, tw-passage h1, .passage h1 {
+    color: #1e3a8a !important;
+    font-size: 2.5em !important;
+    text-align: center !important;
+    margin: 0 0 10px 0 !important;
+    padding: 0 !important;
+    text-indent: 0 !important;
+}
+
+h2, #passages h2, tw-passage h2, .passage h2 {
+    color: #1e3a8a !important;
+    font-size: 1.5em !important;
+    margin: 20px 0 10px 0 !important;
+    padding: 0 0 8px 0 !important;
+    border-bottom: none solid #1e3a8a !important;
+    border-top: none !important;
+    text-indent: 0 !important;
+    text-align: left !important;
+}
+
+h3, #passages h3, tw-passage h3, .passage h3 {
+    color: #2E8B57 !important;
+    margin: 0 0 10px 0 !important;
+    padding: 0 !important;
+    font-size: 1.3em !important;
+    text-indent: 0 !important;
+}
+
+p, #passages p, tw-passage p, .passage p {
+    margin: 3px 0 !important;
+    padding: 15px !important;
+    line-height: 1.4 !important;
+    text-indent: 0 !important;
+    color: #110d2b;
+}
+
+#passages > *:first-child,
+tw-passage > *:first-child,
+.passage > *:first-child,
+.card > *:first-child {
+    margin-top: 0 !important;
+}
+
+/* Remove any default list styling and indentation */
+ul, ol, li {
+    list-style: none !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    text-indent: 0 !important;
+}
+
+/* Ensure no elements have text-indent */
+* {
+    text-indent: 0 !important;
+}
+
+.card {
+    background: white;
+    border-radius: 15px;
+    box-shadow: 0 10px 30px rgba(0,0,0,0.2);
+    max-width: 750px;
+    width: 95%;
+    padding: 40px 55px;
+    display: none;
+    position: relative;
+    border: 3px solid #2E8B57;
+    overflow-y: auto;
+    margin: 20px auto;
+    box-sizing: border-box;
+}
+
+@media (max-width: 768px) {
+    .card, #passages {
+        width: 95% !important;
+        padding: 20px 30px !important;
+        margin: 10px auto !important;
+        border-radius: 10px !important;
+    }
+    
+    h1 {
+        font-size: 2em !important;
+    }
+    
+    h2 {
+        font-size: 1.3em !important;
+    }
+}
+
+.card.active {
+    display: block;
+    animation: fadeIn 0.5s ease-in;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; transform: translateY(20px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+.card-header {
+    border-bottom: 2px solid #2E8B57;
+    margin-bottom: 15px !important;
+    padding-bottom: 10px !important;
+}
+
+.card-title {
+    font-size: 2.2em !important;
+    color: #2E8B57 !important;
+    margin: 0 0 5px 0 !important;
+    padding: 0 !important;
+    text-align: center !important;
+    border: none !important;
+}
+
+.card-subtitle {
+    font-size: 1.1em !important;
+    color: #666 !important;
+    text-align: center !important;
+    font-style: italic !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    border: none !important;
+}
+
+.card-content {
+    line-height: 1.4 !important;
+    color: #333 !important;
+    margin-bottom: 30px !important;
+    padding: 0 !important;
+}
+
+.temple-image {
+    width: 100%;
+    height: 250px;
+    object-fit: cover;
+    border-radius: 10px;
+    margin: 15px 0 !important;
+    padding: 0 !important;
+    box-shadow: 0 5px 15px rgba(0,0,0,0.3);
+}
+
+.highlight {
+    background-color: #1e3a8a !important;
+    color: white !important;
+    padding: 20px !important;
+    border-radius: 8px !important;
+    border-left: 4px solid #3b82f6 !important;
+    margin: 20px 0 !important;
+    border: 20px 0 !important;
+    font-style: italic !important;
+    font-weight: 500 !important;
+}
+
+/* Collapsible Location Styles */
+.location-section {
+    background-color: #e8f4fd;
+    border: 2px solid #bee5eb;
+    border-radius: 10px;
+    margin: 20px 0;
+
+}
+
+.location-toggle {
+    padding: 6px 12px !important;
+    margin: 0 !important;
+    cursor: pointer;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    transition: all 0.3s ease;
+    user-select: none;
+}
+
+.location-toggle:hover {
+    background-color: #d1ecf1;
+    border-radius: 8px;
+}
+
+.location-label {
+    color: #0c5460 !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    font-size: 1.05em !important;
+    font-weight: bold !important;
+    display: flex;
+    align-items: margin-left;
+    gap: 8px;
+}
+
+.toggle-icon {
+    color: #0c5460 !important;
+    font-size: 1.2em !important;
+    font-weight: bold !important;
+    transition: transform 0.3s ease;
+    min-width: 20px !important;
+    text-align: center !important;
+    display: block !important;
+    visibility: visible !important;
+    flex-shrink: 0 !important;
+}
+
+.location-content {
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height 0.3s ease, padding 0.3s ease;
+}
+
+.location-content.expanded {
+    max-height: 300px;
+    padding: 0 20px 20px;
+}
+
+.address {
+    margin-bottom: 8px !important;
+    padding: 0 !important;
+    line-height: 1.4 !important;
+}
+
+.address-label {
+    font-weight: bold !important;
+    color: #0c5460 !important;
+    display: inline-block;
+    min-width: 80px;
+}
+
+.address-text {
+    font-family: monospace !important;
+    background: white !important;
+    padding: 4px 8px !important;
+    border-radius: 4px !important;
+    margin-left: 10px !important;
+}
+
+
+.maps-link:hover {
+    background: #3367d6 !important;
+    transform: translateY(-2px);
+    box-shadow: 0 5px 15px rgba(66,133,244,0.3);
+}
+
+.wikipedia-link:hover {
+    background: #0052a3 !important;
+    transform: translateY(-2px);
+    box-shadow: 0 5px 15px rgba(0,102,204,0.3);
+}
+
+.navigation {
+    display: flex !important;
+    justify-content: space-around !important;
+    flex-wrap: wrap !important;
+    gap: 10px !important;
+    border: 20px 0 !important;
+    margin-top: 20px !important;
+    padding-top: 15px !important;
+    border-top: 1px solid #ddd !important;
+}
+
+@media (max-width: 768px) {
+    .navigation {
+        flex-direction: column !important;
+        gap: 15px !important;
+    }
+}
+
+.nav-link, .wikipedia-link, .maps-link  {
+    background: #2E8B57 !important;
+    color: white !important;
+    text-decoration: none !important;
+    padding: 20px 40px !important;
+    border-radius: 35px !important;
+    font-weight: bold !important;
+    transition: all 0.3s ease;
+    text-align: center !important;
+    min-width: 150px !important;
+    cursor: pointer;
+    display: block !important;
+}
+
+.nav-link:hover {
+    background: #228B22 !important;
+    transform: translateY(-2px);
+    box-shadow: 0 5px 15px rgba(0,0,0,0.2);
+}
+
+.card-number {
+    position: absolute;
+    top: 10px;
+    right: 15px;
+    background: #2E8B57 !important;
+    color: white !important;
+    width: 30px;
+    height: 30px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: bold !important;
+}
+
+.toc-grid {
+    display: grid !important;
+    gap: 15px !important;
+    margin: 20px 0 !important;
+    padding: 0 !important;
+}
+
+.toc-item {
+    border: 2px solid #2E8B57 !important;
+    border-radius: 10px !important;
+    padding: 15px !important;
+    margin: 0 !important;
+    transition: all 0.3s ease;
+    background: white !important;
+    display: block !important;
+}
+
+.toc-item:hover {
+    background-color: #f0f8ff !important;
+    transform: translateY(-2px);
+    box-shadow: 0 5px 15px rgba(0,0,0,0.1);
+}
+
+.toc-item h3 {
+    color: #2E8B57 !important;
+    margin: 0 0 10px 0 !important;
+    padding: 0 !important;
+    font-size: 1.3em !important;
+}
+
+.toc-item h3 a {
+    text-decoration: none !important;
+    color: inherit !important;
+}
+
+.toc-item p {
+    margin: 0 !important;
+    padding: 0 !important;
+    color: #666 !important;
+}
+
+/* Hide Twine UI sidebar */
+#ui-bar {
+    display: none !important;
+}
+
+/* Clean link styling */
+a {
+    text-decoration: none !important;
+}
+
+/* FINAL OVERRIDE - Must be at the end to beat SugarCube defaults */
+/* Target specific SugarCube color variables and elements */
+:root {
+    --primary-color: #1e3a8a !important;
+    --header-color: #1e3a8a !important;
+}
+
+/* Override SugarCube's passage rendering */
+tw-passage h1,
+tw-passage h2,
+tw-story h1,
+tw-story h2,
+html tw-passage h1,
+html tw-passage h2 {
+    color: #1e3a8a !important;
+    text-indent: 0 !important;
+    margin-left: 0 !important;
+    padding-left: 0 !important;
+}
+
+/* Target the actual rendered passage content */
+[data-passage="Table of Contents"] h1,
+[data-passage="Table of Contents"] h2,
+.passage h1,
+.passage h2 {
+    color: #1e3a8a !important;
+    text-indent: 0 !important;
+    margin-left: 0 !important;
+    padding-left: 0 !important;
+}
+
+/* Force override any SugarCube theme colors */
+#story h1, #story h2, #story h3,
+#passages h1, #passages h2, #passages h3 {
+    color: #1e3a8a !important;
+    text-indent: 0 !important;
+    margin-left: 0 !important;
+    padding-left: 0 !important;
+}
+
+/* Specific override for "Osaka City Guide" title */
+h1:contains("Osaka City Guide"),
+h1:contains("大阪"),
+[data-passage="Table of Contents"] > h1:first-of-type {
+    color: #1e3a8a !important;
+    text-indent: 0 !important;
+    margin-left: 0 !important;
+    padding-left: 0 !important;
+}
+
+/* CRITICAL: Remove all default spacing and indentation from SugarCube */
+#passages > *, tw-passage > *, .passage > * {
+    text-indent: 0 !important;
+    margin-left: 0 !important;
+    padding-left: 0 !important;
+}
+
+/* Exception: Don't override location toggle colors */
+.location-toggle *, .location-label *, .toggle-icon {
+    color: inherit !important;
+}
+
+/* Ensure no automatic paragraph spacing */
+#passages p + p, tw-passage p + p, .passage p + p {
+    margin-top: 3px !important;
+}
+
+/* Override any default browser/SugarCube margins */
+body, html {
+    margin: 0 !important;
+    padding: 0 !important;
+}
+
+/* Force consistent spacing throughout */
+#passages * {
+    box-sizing: border-box !important;
+}
+
+.footer {
+  font-size: 0.8em;
+  text-align: center;
+  color: #666;
+}
+
+br {
+  line-height: 1px;
+}


### PR DESCRIPTION
## Summary
- add a new `osaka1` Twine story modeled on the nikko site with updated metadata
- author four walkable Osaka neighborhood attraction passages and a transport guide from KIX to OMO Kansai Airport

## Testing
- scripts/build.sh

------
https://chatgpt.com/codex/tasks/task_e_68d921154b188330839cbf9161f2dbb8