### PR TITLE
Add package transfer guidance to Osaka transport section

### DIFF
--- a/stories/osaka1/01_passages/package-transfers.twee
+++ b/stories/osaka1/01_passages/package-transfers.twee
@@ -1,0 +1,82 @@
+:: Package Transfers
+<div class="card active" id="card-package-transfers">
+<div class="card-number">T4</div>
+<div class="card-header">
+<h1 class="card-title">宅急便で荷物転送</h1>
+<h1 class="card-title">Package Transfers</h1>
+</div>
+
+<p>Here’s a super-handy Japan travel trick you’ll love: forward (ship) your luggage so you can ride trains and bounce between cities with only a small daypack.</p>
+
+<h2>What it’s called</h2>
+<ul>
+<li>Takkyūbin (宅急便) or ta-q-bin = door-to-door luggage delivery.</li>
+</ul>
+
+<h2>Why use it</h2>
+<ul>
+<li>Skip hauling suitcases through stations, crowds, stairs, and bus transfers.</li>
+<li>Perfect for multi-city runs (e.g., Osaka → Kyoto → Nikko) with day stops in between.</li>
+</ul>
+
+<h2>How it works (quick steps)</h2>
+<ol>
+<li>Pack &amp; label your suitcase. Keep meds and valuables with you.</li>
+<li>Arrange shipping at your hotel front desk or a counter at airports and major stations (look for Yamato/“Kuroneko,” JAL ABC, Sagawa).</li>
+<li>Fill the slip (destination hotel name, address, phone; your name; desired delivery date).</li>
+<li>Choose timing: standard is next-day (1 day) or two-day depending on distance and cutoff time.</li>
+<li>Pay at the counter (cash or card; price depends on size and distance—typically modest vs. a taxi).</li>
+<li>Travel light with a 1–2-day overnight kit while your main bag flies ahead.</li>
+</ol>
+
+<h2>Pro tip for multi-stops (your case)</h2>
+<ul>
+<li>If you plan to pause in a city en route, ship your big bag two days ahead to the final hotel, and carry a small overnight bag for the intermediary stop(s). You stay nimble and skip station lockers.</li>
+</ul>
+
+<h2>Hotel vs. station delivery</h2>
+<ul>
+<li><strong>Hotel → Hotel:</strong> Easiest. Most hotels happily send and receive; they’ll hold bags until check-in.</li>
+<li><strong>Hotel ↔︎ Station counter:</strong> Useful if you want pickup near trains. Confirm counter hours; bring the claim slip to collect.</li>
+<li><strong>Airport ↔︎ Hotel/Station:</strong> Common on arrival and departure days.</li>
+</ul>
+
+<h2>Cut-offs &amp; timing</h2>
+<ul>
+<li>Send before late morning for best chance at next-day delivery; otherwise expect plus one day.</li>
+<li>Rural areas may take an extra day.</li>
+</ul>
+
+<h2>What you’ll need</h2>
+<ul>
+<li>Destination hotel name, address, phone (in Japanese if you have it—front desks will help).</li>
+<li>Your name (matching the hotel booking).</li>
+<li>Contact number (a mobile works).</li>
+<li>ID isn’t usually required to ship; pickup at some station or airport counters may ask to see the shipping receipt (keep it!) and occasionally ID.</li>
+</ul>
+
+<h2>Packing &amp; labeling</h2>
+<ul>
+<li>Put your name plus check-in date on the bag tag.</li>
+<li>Don’t ship passports, cash, laptops, or fragile items.</li>
+<li>Use a hard tag or tape a paper tag under clear tape so it won’t tear off.</li>
+</ul>
+
+<h2>Typical costs (ballpark)</h2>
+<ul>
+<li>Similar to a short taxi ride, varying by size and distance. One large suitcase is usually reasonable; golf or ski bags cost a bit more.</li>
+</ul>
+
+<h2>Language help</h2>
+<ul>
+<li>Say: “Takkyūbin onegaishimasu” (I’d like luggage delivery, please).</li>
+<li>Most counters and hotels have bilingual forms; staff can fill them out if you show your booking.</li>
+</ul>
+
+<p>If you want, tell me your exact hops and dates (e.g., “Oct 2–4 Osaka, Oct 5–8 Kyoto, Oct 9 Nikko”), and I’ll map out when and where to hand off bags plus the exact counters to use at your stations and hotels.</p>
+
+<div class="navigation">
+<a class="nav-link" data-passage="Table of Contents">← Back to Table of Contents</a>
+<a class="nav-link" data-passage="KIX to OMO Kansai Airport Hotel">Next: KIX Arrival Options →</a>
+</div>
+</div>

--- a/stories/osaka1/01_passages/start.twee
+++ b/stories/osaka1/01_passages/start.twee
@@ -61,6 +61,11 @@
 </div>
 
 <div class="toc-item">
+<h3>[[📦 Package Transfers->Package Transfers]]</h3>
+<p>Ship suitcases ahead so you can hop trains with just a daypack.</p>
+</div>
+
+<div class="toc-item">
 <h3>[[✈️ KIX to OMO Kansai Airport Hotel->KIX to OMO Kansai Airport Hotel]]</h3>
 <p>Compare trains, shuttle buses, and late-night options to reach the on-airport stay.</p>
 </div>


### PR DESCRIPTION
## Summary
- add a Package Transfers tile to the Osaka transport table of contents
- write a detailed Package Transfers passage covering luggage-forwarding steps and tips

## Testing
- not run (content-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68ddaf64e11883308aabbe91d2cc500b