### PR TITLE
Add Osaka festival section highlighting Futon Daiko and Danjiri events

### DIFF
--- a/stories/osaka1/01_passages/danjiri-festival.twee
+++ b/stories/osaka1/01_passages/danjiri-festival.twee
@@ -1,0 +1,168 @@
+:: Danjiri Festival
+<div class="card active" id="card-danjiri">
+  <div class="card-number">F2</div>
+  <div class="card-header">
+    <h1 class="card-title">だんじり祭</h1>
+    <h1 class="card-title">Danjiri Festival</h1>
+  </div>
+
+  <div class="highlight">
+    <strong>Wooden Floats in Full Sprint</strong><br>
+    • Saturday, October 4 features seven danjiri teams charging through Sakai's streets from dawn pull-outs to evening torch runs.<br>
+    • Carvers spend months polishing each cedar float; the front roof carries the shrine's guardian dragon while the rear stage hosts live musicians.<br>
+    • Watch for the high-speed "yarimawashi" cornering technique—ropes snap tight and the float drifts sideways at intersections.
+  </div>
+
+  <p>Danjiri are ornately carved festival floats pulled by ropes rather than carried. Sakai's tradition dates back to 1703 when carver Kishiwada Danjiri master Nakai Danjuro introduced the style to neighborhood guilds seeking dramatic autumn processions. The festival honors ujigami guardian deities, thanking them for harvests and commercial prosperity while rallying community teamwork. Each float can weigh up to four tons, so dozens of runners guide it while musicians pound taiko and clang kane gongs from the upper stage.</p>
+
+  <p>Compared with Futon Daiko, danjiri emphasize speed and precision steering. Teams in traditional happi coats sprint, brake, and swing the float to the rhythm of "sorya, sorya" chants. Night runs swap to paper lantern illumination, revealing woodcarvings that depict mythic battles, sea bream, and lion dogs protecting the shrine. Visitors should stand behind designated rope lines—when the signal whistles blow, the float may accelerate without warning.</p>
+
+  <h2>Danjiri Runs Scheduled for Saturday, October 4</h2>
+
+  <h3>Ishizu Jinja (石津神社)</h3>
+  <p>The Ishizu danjiri opens the morning with a blessing in front of the honden before joining the Futon Daiko lineup at dusk. Local shipwright families lead the pull, tracing a loop through Ishizu's grid of port warehouses.</p>
+  <div class="location-section">
+    <div class="location-toggle" onclick="toggleLocation('location-ishizu-danjiri')">
+      <div class="location-label">📍 Location & Access</div>
+      <div class="toggle-icon" id="icon-ishizu-danjiri">+</div>
+    </div>
+    <div class="location-content" id="location-ishizu-danjiri">
+      <div class="address">
+        <span class="address-label">Neighborhood:</span>
+        <span class="address-text">Ishizu port area, Nishi Ward, Sakai</span>
+      </div>
+      <div class="address">
+        <span class="address-label">Nearest Station:</span>
+        <span class="address-text">Ishizugawa Station (Nankai Main Line)</span>
+      </div>
+      <a href="https://maps.google.com/?q=Ishizu+Jinja+Sakai" target="_blank" class="maps-link">🗺️ Open in Google Maps</a>
+    </div>
+  </div>
+
+  <h3>Ōtori Taisha (大鳥大社)</h3>
+  <p>Sakai's grand Ōtori Taisha sends a massive danjiri from its stone torii toward Ōtori Station, accompanied by a lion-dance troupe. The float's carvings highlight the mythic phoenix that symbolizes the shrine's fire-protection miracles.</p>
+  <div class="location-section">
+    <div class="location-toggle" onclick="toggleLocation('location-ootori-danjiri')">
+      <div class="location-label">📍 Location & Access</div>
+      <div class="toggle-icon" id="icon-ootori-danjiri">+</div>
+    </div>
+    <div class="location-content" id="location-ootori-danjiri">
+      <div class="address">
+        <span class="address-label">Neighborhood:</span>
+        <span class="address-text">Ōtori Higashi-chō, Nishi Ward, Sakai</span>
+      </div>
+      <div class="address">
+        <span class="address-label">Nearest Station:</span>
+        <span class="address-text">Ōtori Station (JR Hanwa Line)</span>
+      </div>
+      <a href="https://maps.google.com/?q=Ootori+Taisha" target="_blank" class="maps-link">🗺️ Open in Google Maps</a>
+    </div>
+  </div>
+
+  <h3>Kusabe Jinja (草部神社)</h3>
+  <p>Kusabe's danjiri highlights agrarian motifs because the shrine protects Sakai's farming hamlets. The float starts before sunrise so it can visit each parish's granary en route to Ōtori Avenue.</p>
+  <div class="location-section">
+    <div class="location-toggle" onclick="toggleLocation('location-kusabe-danjiri')">
+      <div class="location-label">📍 Location & Access</div>
+      <div class="toggle-icon" id="icon-kusabe-danjiri">+</div>
+    </div>
+    <div class="location-content" id="location-kusabe-danjiri">
+      <div class="address">
+        <span class="address-label">Neighborhood:</span>
+        <span class="address-text">Kusabe district, Nishi Ward, Sakai</span>
+      </div>
+      <div class="address">
+        <span class="address-label">Nearest Station:</span>
+        <span class="address-text">Tsukuno Station (JR Hanwa Line)</span>
+      </div>
+      <a href="https://maps.google.com/?q=Kusabe+Jinja" target="_blank" class="maps-link">🗺️ Open in Google Maps</a>
+    </div>
+  </div>
+
+  <h3>Tajihayahime Jinja (多治速比売神社)</h3>
+  <p>This shrine guards the ancient Mozu kofun basin and celebrates Princess Tajihayahime. Its danjiri showcases refined carvings of imperial messengers and features a nighttime stop at the famed torii framed by pine trees.</p>
+  <div class="location-section">
+    <div class="location-toggle" onclick="toggleLocation('location-tajihayahime-danjiri')">
+      <div class="location-label">📍 Location & Access</div>
+      <div class="toggle-icon" id="icon-tajihayahime-danjiri">+</div>
+    </div>
+    <div class="location-content" id="location-tajihayahime-danjiri">
+      <div class="address">
+        <span class="address-label">Neighborhood:</span>
+        <span class="address-text">Mikunigaoka area, Sakai Ward</span>
+      </div>
+      <div class="address">
+        <span class="address-label">Nearest Station:</span>
+        <span class="address-text">Mikunigaoka Station (JR Hanwa Line)</span>
+      </div>
+      <a href="https://maps.google.com/?q=Tajihayahime+Jinja" target="_blank" class="maps-link">🗺️ Open in Google Maps</a>
+    </div>
+  </div>
+
+  <h3>Nonomiya Jinja (野々宮神社)</h3>
+  <p>Nonomiya's float is compact but swift, weaving through residential lanes before merging with the Ōtori Taisha procession. Local children ride on the rear deck to scatter good-luck talismans.</p>
+  <div class="location-section">
+    <div class="location-toggle" onclick="toggleLocation('location-nonomiya-danjiri')">
+      <div class="location-label">📍 Location & Access</div>
+      <div class="toggle-icon" id="icon-nonomiya-danjiri">+</div>
+    </div>
+    <div class="location-content" id="location-nonomiya-danjiri">
+      <div class="address">
+        <span class="address-label">Neighborhood:</span>
+        <span class="address-text">Nonomiya-chō, Nishi Ward, Sakai</span>
+      </div>
+      <div class="address">
+        <span class="address-label">Nearest Station:</span>
+        <span class="address-text">Tsukuno Station (JR Hanwa Line)</span>
+      </div>
+      <a href="https://maps.google.com/?q=Nonomiya+Jinja+Sakai" target="_blank" class="maps-link">🗺️ Open in Google Maps</a>
+    </div>
+  </div>
+
+  <h3>Hishiki Jinja (菱木神社)</h3>
+  <p>Hishiki Jinja's danjiri emphasizes lumber trade scenes—look for woodcutters carved into the side panels. The float charges along Prefectural Route 30 before turning sharply into the shrine's cedar grove.</p>
+  <div class="location-section">
+    <div class="location-toggle" onclick="toggleLocation('location-hishiki-danjiri')">
+      <div class="location-label">📍 Location & Access</div>
+      <div class="toggle-icon" id="icon-hishiki-danjiri">+</div>
+    </div>
+    <div class="location-content" id="location-hishiki-danjiri">
+      <div class="address">
+        <span class="address-label">Neighborhood:</span>
+        <span class="address-text">Hishiki, Nishi Ward, Sakai</span>
+      </div>
+      <div class="address">
+        <span class="address-label">Nearest Station:</span>
+        <span class="address-text">Tsukuno Station (JR Hanwa Line) via community shuttle</span>
+      </div>
+      <a href="https://maps.google.com/?q=Hishiki+Jinja" target="_blank" class="maps-link">🗺️ Open in Google Maps</a>
+    </div>
+  </div>
+
+  <h3>Tsukuno Hachiman Jinja (宿野八幡神社)</h3>
+  <p>Tsukuno's Hachiman shrine fields a danjiri with elaborate hawk carvings paying homage to the warrior deity. Evening runs feature synchronized lantern swings that make the float appear to breathe.</p>
+  <div class="location-section">
+    <div class="location-toggle" onclick="toggleLocation('location-tsukuno-danjiri')">
+      <div class="location-label">📍 Location & Access</div>
+      <div class="toggle-icon" id="icon-tsukuno-danjiri">+</div>
+    </div>
+    <div class="location-content" id="location-tsukuno-danjiri">
+      <div class="address">
+        <span class="address-label">Neighborhood:</span>
+        <span class="address-text">Tsukuno, Nishi Ward, Sakai</span>
+      </div>
+      <div class="address">
+        <span class="address-label">Nearest Station:</span>
+        <span class="address-text">Tsukuno Station (JR Hanwa Line), 4-minute walk</span>
+      </div>
+      <a href="https://maps.google.com/?q=Tsukuno+Hachiman+Jinja" target="_blank" class="maps-link">🗺️ Open in Google Maps</a>
+    </div>
+  </div>
+
+  <p><strong>Viewing advice:</strong> Morning pull-outs (around 6:00 a.m.) are less crowded and great for photos. By evening, secure a spot at wide intersections such as Ōtori Ekimae or Tsukuno Crossing to watch yarimawashi turns. Earplugs help if you stand near the taiko deck.</p>
+
+  <div class="navigation">
+    <a class="nav-link" data-passage="Futon Daiko Festival">← Futon Daiko Festival</a>
+    <a class="nav-link" data-passage="Table of Contents">Back to Table of Contents →</a>
+  </div>
+</div>

--- a/stories/osaka1/01_passages/futon-daiko-festival.twee
+++ b/stories/osaka1/01_passages/futon-daiko-festival.twee
@@ -1,0 +1,88 @@
+:: Futon Daiko Festival
+<div class="card active" id="card-futon-daiko">
+  <div class="card-number">F1</div>
+  <div class="card-header">
+    <h1 class="card-title">布団太鼓</h1>
+    <h1 class="card-title">Futon Daiko Festival</h1>
+  </div>
+
+  <div class="highlight">
+    <strong>October 4 Spotlight</strong><br>
+    • Sakai's Futon Daiko troupes parade massive taiko-laden floats through neighborhood streets after dusk.<br>
+    • Processions depart each shrine in the late afternoon, regroup for nighttime lantern runs, and return before midnight.<br>
+    • Expect intense chanting, shoulder-borne floats weighing over a ton, and handheld fireworks along the route.
+  </div>
+
+  <p>Futon Daiko ("quilt drum") is Sakai's signature autumn festival tradition. Teams of carriers hoist a lacquered shrine float crowned with five tiers of brocade futon cushions surrounding a barrel drum. The layered bedding honors the deity's comfort while the thunderous taiko beat drives out misfortune and summons a bountiful season for the port city. The custom dates to the Edo period, when Sakai's merchants sponsored luxurious futon to thank the gods for safe trade winds and prosperous harvests.</p>
+
+  <p>Unlike wheeled danjiri, Futon Daiko floats sway on the shoulders of 40–60 bearers. A lead drummer hammers out complex rhythms while a bamboo fife band and call-and-response chants keep the crew in sync. Night runs are spectacular: lanterns outline the futon tiers, torches flare at corners, and the float is rocked wildly to show the community's strength. Spectators can stand close to the action, but stay behind ropes when the teams break into "mawari" spins at intersections.</p>
+
+  <h2>Where to See Futon Daiko on Saturday, October 4</h2>
+
+  <h3>Ishizu Jinja (石津神社)</h3>
+  <p>Ishizu's maritime parish is home to one of Sakai's most dramatic Futon Daiko performances. The float honors the sea deity enshrined here, and two carved danjiri carts join the parade so the shrine's guilds can showcase both traditions in a single evening. Expect the courtyard to fill quickly once the carriers shoulder the float around 6:30 p.m.</p>
+  <div class="location-section">
+    <div class="location-toggle" onclick="toggleLocation('location-ishizu-daiko')">
+      <div class="location-label">📍 Location & Access</div>
+      <div class="toggle-icon" id="icon-ishizu-daiko">+</div>
+    </div>
+    <div class="location-content" id="location-ishizu-daiko">
+      <div class="address">
+        <span class="address-label">Neighborhood:</span>
+        <span class="address-text">Ishizu port area, Nishi Ward, Sakai</span>
+      </div>
+      <div class="address">
+        <span class="address-label">Nearest Station:</span>
+        <span class="address-text">Ishizugawa Station (Nankai Main Line), 8-minute walk</span>
+      </div>
+      <a href="https://maps.google.com/?q=Ishizu+Jinja+Sakai" target="_blank" class="maps-link">🗺️ Open in Google Maps</a>
+    </div>
+  </div>
+
+  <h3>Kahyo Jinja (加茂神社)</h3>
+  <p>Hamadera's Kahyo Jinja sends its Futon Daiko along pine-lined streets near the seaside park. The shrine's youth association is known for agile shoulder work that makes the float hop on command—a sight best photographed near the Hamadera canal bridge when torches ignite at dusk.</p>
+  <div class="location-section">
+    <div class="location-toggle" onclick="toggleLocation('location-kahyo-daiko')">
+      <div class="location-label">📍 Location & Access</div>
+      <div class="toggle-icon" id="icon-kahyo-daiko">+</div>
+    </div>
+    <div class="location-content" id="location-kahyo-daiko">
+      <div class="address">
+        <span class="address-label">Neighborhood:</span>
+        <span class="address-text">Hamadera coastal district, Nishi Ward, Sakai</span>
+      </div>
+      <div class="address">
+        <span class="address-label">Nearest Station:</span>
+        <span class="address-text">Hamaderakōen Station (Nankai Main Line), 5-minute walk</span>
+      </div>
+      <a href="https://maps.google.com/?q=Kahyo+Jinja+Sakai" target="_blank" class="maps-link">🗺️ Open in Google Maps</a>
+    </div>
+  </div>
+
+  <h3>Mozu Hachimangū (百舌鳥八幡宮)</h3>
+  <p>Located beside the UNESCO-listed Mozu kofun cluster, Mozu Hachimangū features a Futon Daiko that threads between ancient keyhole tombs. Families gather in front of the honden to cheer as the float is raised high in a "tobiage" bounce before it proceeds toward the Mozu shopping street. Lantern-lit moats make this stop particularly atmospheric.</p>
+  <div class="location-section">
+    <div class="location-toggle" onclick="toggleLocation('location-mozu-daiko')">
+      <div class="location-label">📍 Location & Access</div>
+      <div class="toggle-icon" id="icon-mozu-daiko">+</div>
+    </div>
+    <div class="location-content" id="location-mozu-daiko">
+      <div class="address">
+        <span class="address-label">Neighborhood:</span>
+        <span class="address-text">Mozu area, Kita Ward, Sakai</span>
+      </div>
+      <div class="address">
+        <span class="address-label">Nearest Station:</span>
+        <span class="address-text">Mozu Station (JR Hanwa Line), 6-minute walk</span>
+      </div>
+      <a href="https://maps.google.com/?q=Mozu+Hachimangu" target="_blank" class="maps-link">🗺️ Open in Google Maps</a>
+    </div>
+  </div>
+
+  <p><strong>Tips for visitors:</strong> Wear closed-toe shoes, stay outside the guard ropes when the carriers shout "sorya!" and charge forward, and be ready for sudden crowd surges when the floats enter narrow streets. Portable restrooms are usually set up near each shrine's precincts, and food stalls line the approach from late afternoon.</p>
+
+  <div class="navigation">
+    <a class="nav-link" data-passage="Table of Contents">← Back to Table of Contents</a>
+    <a class="nav-link" data-passage="Danjiri Festival">Next: Danjiri Festival →</a>
+  </div>
+</div>

--- a/stories/osaka1/01_passages/start.twee
+++ b/stories/osaka1/01_passages/start.twee
@@ -42,6 +42,20 @@
 </div>
 </div>
 
+<h2>Festivals ▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃</h2>
+
+<div class="toc-grid">
+<div class="toc-item">
+<h3>[[🥁 Futon Daiko Festival->Futon Daiko Festival]]</h3>
+<p>Lantern-lit shoulder floats topped with brocade futon thunder through Sakai's shrines.</p>
+</div>
+
+<div class="toc-item">
+<h3>[[🪵 Danjiri Festival->Danjiri Festival]]</h3>
+<p>Carved wooden danjiri sprint through port streets with high-speed cornering displays.</p>
+</div>
+</div>
+
 <h2>Transport ▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃</h2>
 
 <div class="toc-grid">


### PR DESCRIPTION
## Summary
- add a Festivals section to the Osaka table of contents linking to Futon Daiko and Danjiri coverage
- author a Futon Daiko Festival card with history, viewing tips, and October 4 shrine details for Ishizu, Kahyo, and Mozu Hachimangu
- create a Danjiri Festival card outlining the tradition and providing location info for the seven shrines running floats on October 4

## Testing
- ./scripts/build.sh *(fails: missing .bin/tweego binary in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ddc806b40483309e0686e64ba4823b