### PR TITLE
Wrap shared widget macro in script tag

### DIFF
--- a/shared/macros/widgets.js
+++ b/shared/macros/widgets.js
@@ -1,1 +1,19 @@
-(function(){ if(!window.Macro||!Macro.add)return; Macro.add('templeFact',{handler(){const n=String(this.args[0]||''); const f={Kiyomizu:'Famous wooden stage.',Inari:'Thousands of vermilion torii.',Kinkakuji:'Golden pavilion over Mirror Pond.'}; this.output.append(f[n]||'');}}); })();
+<script>
+(function(){
+  if (!window.Macro || !Macro.add) {
+    return;
+  }
+
+  Macro.add('templeFact', {
+    handler() {
+      const n = String(this.args[0] || '');
+      const f = {
+        Kiyomizu: 'Famous wooden stage.',
+        Inari: 'Thousands of vermilion torii.',
+        Kinkakuji: 'Golden pavilion over Mirror Pond.'
+      };
+      this.output.append(f[n] || '');
+    }
+  });
+})();
+</script>


### PR DESCRIPTION
## Summary
- wrap the shared templeFact widget macro in a script tag so it is executed instead of appearing as plain text

## Testing
- scripts/build.sh *(fails: scripts/build.sh: line 14: .bin/tweego: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68de83c0dfc883309e2584887eeac751