### PR TITLE
Create all1 deck with logistics and history cards

### DIFF
--- a/stories/all1/00_meta.twee
+++ b/stories/all1/00_meta.twee
@@ -1,0 +1,20 @@
+:: StoryTitle
+Japan Travel Essentials
+
+:: StoryData
+{
+  "ifid": "be45f1d9-24be-4cad-ba93-109ff2602f10",
+  "format": "SugarCube",
+  "format-version": "2.36.1",
+  "start": "general1",
+  "zoom": 1
+}
+
+:: StoryStylesheet [stylesheet]
+@import url("./assets/styles.css");
+
+:: Story JavaScript [script]
+// Load functional JavaScript for location toggle
+var script = document.createElement('script');
+script.src = 'assets/scripts.js';
+document.head.appendChild(script);

--- a/stories/all1/01_passages/general1.twee
+++ b/stories/all1/01_passages/general1.twee
@@ -1,0 +1,43 @@
+:: StoryConfig [init]
+<<run Config.passages.nobr = true>>
+
+:: general1
+<div class="card active" id="card1">
+  <div class="card-number">0</div>
+  <div class="card-header">
+    <h1 class="card-title">旅の基礎</h1>
+    <h1 class="card-title">Japan Travel Essentials</h1>
+  </div>
+
+  <p>This deck gathers practical logistics advice and cultural context cards you can drop into any Kansai or Kanto itinerary. Use these highlights as a quick reference when stitching together multi-city journeys.</p>
+
+  <h2>Logistics ▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃</h2>
+
+  <div class="toc-grid">
+    <div class="toc-item">
+      <h3>[[📦 Package Transfers->Package Transfers]]</h3>
+      <p>Ship suitcases ahead so you can hop trains with just a daypack.</p>
+    </div>
+
+    <div class="toc-item">
+      <h3>[[🚕 Ridesharing->Ridesharing]]</h3>
+      <p>Compare Uber, DiDi, and GO taxi apps before you request a ride.</p>
+    </div>
+  </div>
+
+  <h2>History ▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃▃</h2>
+
+  <div class="toc-grid">
+    <div class="toc-item">
+      <h3>[[🧘 Zen in Sakai and Osaka->Zen in Sakai and Osaka]]</h3>
+      <p>The history of Zen Buddhism in Sakai and Osaka, from Ikkyū's revolutionary teachings to Sen no Rikyū's tea ceremony philosophy.</p>
+    </div>
+  </div>
+
+  <div class="navigation">
+    <a class="nav-link" data-passage="Package Transfers">Start with Package Transfers →</a>
+  </div>
+</div>
+
+:: PassageFooter
+<p class="footer">2025-09-18 Twine Japan</p>

--- a/stories/all1/01_passages/package-transfers.twee
+++ b/stories/all1/01_passages/package-transfers.twee
@@ -1,0 +1,82 @@
+:: Package Transfers
+<div class="card active" id="card-package-transfers">
+<div class="card-number">L1</div>
+<div class="card-header">
+<h1 class="card-title">宅急便で荷物転送</h1>
+<h1 class="card-title">Package Transfers</h1>
+</div>
+
+<p>Here’s a super-handy Japan travel trick you’ll love: forward (ship) your luggage so you can ride trains and bounce between cities with only a small daypack.</p>
+
+<h2>What it’s called</h2>
+<ul>
+<li>Takkyūbin (宅急便) or ta-q-bin = door-to-door luggage delivery.</li>
+</ul>
+
+<h2>Why use it</h2>
+<ul>
+<li>Skip hauling suitcases through stations, crowds, stairs, and bus transfers.</li>
+<li>Perfect for multi-city runs (e.g., Osaka → Kyoto → Nikko) with day stops in between.</li>
+</ul>
+
+<h2>How it works (quick steps)</h2>
+<ol>
+<li>Pack &amp; label your suitcase. Keep meds and valuables with you.</li>
+<li>Arrange shipping at your hotel front desk or a counter at airports and major stations (look for Yamato/“Kuroneko,” JAL ABC, Sagawa).</li>
+<li>Fill the slip (destination hotel name, address, phone; your name; desired delivery date).</li>
+<li>Choose timing: standard is next-day (1 day) or two-day depending on distance and cutoff time.</li>
+<li>Pay at the counter (cash or card; price depends on size and distance—typically modest vs. a taxi).</li>
+<li>Travel light with a 1–2-day overnight kit while your main bag flies ahead.</li>
+</ol>
+
+<h2>Pro tip for multi-stops (your case)</h2>
+<ul>
+<li>If you plan to pause in a city en route, ship your big bag two days ahead to the final hotel, and carry a small overnight bag for the intermediary stop(s). You stay nimble and skip station lockers.</li>
+</ul>
+
+<h2>Hotel vs. station delivery</h2>
+<ul>
+<li><strong>Hotel → Hotel:</strong> Easiest. Most hotels happily send and receive; they’ll hold bags until check-in.</li>
+<li><strong>Hotel ↔︎ Station counter:</strong> Useful if you want pickup near trains. Confirm counter hours; bring the claim slip to collect.</li>
+<li><strong>Airport ↔︎ Hotel/Station:</strong> Common on arrival and departure days.</li>
+</ul>
+
+<h2>Cut-offs &amp; timing</h2>
+<ul>
+<li>Send before late morning for best chance at next-day delivery; otherwise expect plus one day.</li>
+<li>Rural areas may take an extra day.</li>
+</ul>
+
+<h2>What you’ll need</h2>
+<ul>
+<li>Destination hotel name, address, phone (in Japanese if you have it—front desks will help).</li>
+<li>Your name (matching the hotel booking).</li>
+<li>Contact number (a mobile works).</li>
+<li>ID isn’t usually required to ship; pickup at some station or airport counters may ask to see the shipping receipt (keep it!) and occasionally ID.</li>
+</ul>
+
+<h2>Packing &amp; labeling</h2>
+<ul>
+<li>Put your name plus check-in date on the bag tag.</li>
+<li>Don’t ship passports, cash, laptops, or fragile items.</li>
+<li>Use a hard tag or tape a paper tag under clear tape so it won’t tear off.</li>
+</ul>
+
+<h2>Typical costs (ballpark)</h2>
+<ul>
+<li>Similar to a short taxi ride, varying by size and distance. One large suitcase is usually reasonable; golf or ski bags cost a bit more.</li>
+</ul>
+
+<h2>Language help</h2>
+<ul>
+<li>Say: “Takkyūbin onegaishimasu” (I’d like luggage delivery, please).</li>
+<li>Most counters and hotels have bilingual forms; staff can fill them out if you show your booking.</li>
+</ul>
+
+<p>If you want, tell me your exact hops and dates (e.g., “Oct 2–4 Osaka, Oct 5–8 Kyoto, Oct 9 Nikko”), and I’ll map out when and where to hand off bags plus the exact counters to use at your stations and hotels.</p>
+
+<div class="navigation">
+<a class="nav-link" data-passage="general1">← Back to General Overview</a>
+<a class="nav-link" data-passage="Ridesharing">Next: Ridesharing Apps →</a>
+</div>
+</div>

--- a/stories/all1/01_passages/ridesharing.twee
+++ b/stories/all1/01_passages/ridesharing.twee
@@ -1,0 +1,69 @@
+:: Ridesharing
+<div class="card active" id="card-ridesharing">
+  <div class="card-number">L2</div>
+  <div class="card-header">
+    <h1 class="card-title">ライドシェア・配車アプリ</h1>
+    <h1 class="card-title">Ridesharing</h1>
+  </div>
+
+  <p>Uber, DiDi, and GO all operate as taxi-hailing apps in Kansai rather than private cars. Install them before departure so you can compare prices, wait times, and payment options when you land.</p>
+
+  <div class="highlight">
+    <strong>Key tip:</strong> Enable location services and add a Japanese pickup note (copy it from your hotel confirmation) before requesting a car so drivers can find you quickly in busy stations.
+  </div>
+
+  <table class="comparison-table">
+    <thead>
+      <tr>
+        <th>App</th>
+        <th>Tokyo</th>
+        <th>Osaka</th>
+        <th>Kyoto</th>
+        <th>English interface</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>Uber</strong></td>
+        <td>Uber Taxi partners with the big fleets inside the Yamanote loop and airports. Cars usually arrive within 5–10 minutes outside rush hour, and fares follow the taxi meter plus a small booking fee.</td>
+        <td>Coverage is solid across Umeda, Namba, and the bay area. Expect the same metered fares as street cabs; late-night supply is thinner so you may see longer waits after midnight.</td>
+        <td>Availability is moderate. It works best around Kyoto Station, downtown Kawaramachi, and hotel clusters; queue times grow during festivals so keep a backup app handy.</td>
+        <td>Yes — the app defaults to English and supports overseas cards and Apple Pay.</td>
+      </tr>
+      <tr>
+        <td><strong>DiDi</strong></td>
+        <td>Wide Tokyo coverage with live driver chat that auto-translates messages. Frequent coupons appear in the app, and you can choose cash or cashless payment before confirming.</td>
+        <td>Kansai is DiDi’s strongest market. Dispatch is quick in Osaka’s central wards and at Kansai Airport, and airport flat-fare vouchers regularly pop up for new users.</td>
+        <td>Serves Kyoto City plus Arashiyama and Fushimi corridors. Drivers are accustomed to tourists; note that some vehicles are Kyoto’s larger sightseeing taxis, so fares can be slightly higher.</td>
+        <td>Yes — switch languages from the profile screen and the menus, driver chat, and receipts appear in English.</td>
+      </tr>
+      <tr>
+        <td><strong>GO</strong></td>
+        <td>Japan’s largest taxi network with 100,000+ cars. Handy extras include advance airport bookings and the “GO Pay” cashless QR code for street hails.</td>
+        <td>Excellent fleet density around Osaka Station City, Shin-Osaka, and Namba. The app shows driver ETA and taxi company so you can match the vehicle at busy hotel stands.</td>
+        <td>GO recently expanded across Kyoto; coverage is best in the city core and along the Hankyu and JR corridors. Supply dips in the evenings in Arashiyama, so plan to request while still near the station.</td>
+        <td>Yes — toggle English under Menu → Settings; the interface, e-receipts, and support chat switch over while keeping driver notes in Japanese.</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>How to choose</h2>
+  <ul>
+    <li><strong>Compare wait times:</strong> Request from two apps and cancel the slower one before a driver accepts. Osaka taxis usually respond fastest on GO, while Kyoto backups tend to appear on DiDi.</li>
+    <li><strong>Payment flexibility:</strong> Uber and DiDi accept foreign credit cards and Apple Pay. GO supports domestic IC cards via GO Pay; if your overseas card is rejected, switch to cash on arrival.</li>
+    <li><strong>Discount hunting:</strong> New-user coupons rotate often. Check the campaign tab in DiDi and GO before you book longer rides like KIX transfers.</li>
+  </ul>
+
+  <h2>Advice for first-time riders</h2>
+  <ul>
+    <li>Drop the pin on a taxi stand or a wide sidewalk and add a short landmark description (e.g., “At the south exit of Namba Station”).</li>
+    <li>Screenshot the license plate and driver name so you can confirm the correct cab in front of hotel doormen.</li>
+    <li>Keep a translation app ready. Even with English menus, drivers mainly speak Japanese; showing the Japanese address avoids confusion.</li>
+    <li>If the app struggles with an overseas SMS number, ask your hotel concierge to book through their business account or hail from the street and pay with GO Pay or cash.</li>
+  </ul>
+
+  <div class="navigation">
+    <a class="nav-link" data-passage="Package Transfers">← Package Transfers</a>
+    <a class="nav-link" data-passage="Zen in Sakai and Osaka">Next: Zen in Sakai and Osaka →</a>
+  </div>
+</div>

--- a/stories/all1/01_passages/zen-in-sakai-and-osaka.twee
+++ b/stories/all1/01_passages/zen-in-sakai-and-osaka.twee
@@ -1,0 +1,194 @@
+:: Zen in Sakai and Osaka
+<div class="card active" id="card-zen">
+<div class="card-number">H1</div>
+<div class="card-header">
+<h1 class="card-title">禅仏教</h1>
+<h1 class="card-title">Zen in Sakai and Osaka</h1>
+</div>
+
+<img src="https://commons.wikimedia.org/wiki/Special:FilePath/Daitoku-ji_Kyoto02s5s4592.jpg?width=800" alt="Daitokuji Temple Zen garden" class="temple-image">
+
+<div class="highlight">
+<strong>Why This Matters</strong><br>
+Sakai and Osaka played pivotal roles in Japanese Zen Buddhism's development, particularly through the legendary monk Ikkyū and the tea ceremony master Sen no Rikyū. The free-spirited merchant culture of Sakai created a unique environment where Zen philosophy flourished outside traditional temple hierarchies.
+</div>
+
+<h2>Buddhism Arrives in Japan</h2>
+
+<p>Buddhism first reached Japan in the 6th century, traveling from India through China and Korea along the Silk Road. While Shinto—Japan's indigenous faith—predates Buddhism, the two religions evolved together rather than in opposition. Today, most Japanese visit both Buddhist temples and Shinto shrines without viewing this as contradictory.</p>
+
+<p>Zen Buddhism, which emphasizes meditation (zazen) and direct insight over scriptural study, became one of several major Buddhist schools that developed in Japan. The word "Zen" comes from the Chinese "Chan," itself derived from the Sanskrit "dhyana" meaning meditation.</p>
+
+<h2>Historical Timeline of Zen Buddhism in Japan</h2>
+
+<table> 
+<thead>
+<tr>
+<th>Time Period</th>
+<th>Period Name</th>
+<th>Key Developments in Zen</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>538-710 CE</td>
+<td>Asuka Period</td>
+<td>Buddhism first introduced to Japan from Korea; early foundations laid before Zen's formal arrival</td>
+</tr>
+<tr>
+<td>710-794</td>
+<td>Nara Period</td>
+<td>Six traditional Buddhist schools established in Nara; Zen not yet formally introduced</td>
+</tr>
+<tr>
+<td>794-1185</td>
+<td>Heian Period</td>
+<td>Tendai and Shingon Buddhism dominate; early Zen teachings begin filtering in from China</td>
+</tr>
+<tr>
+<td>1185-1333</td>
+<td>Kamakura Period</td>
+<td>Major Zen schools founded: Rinzai (by Eisai, 1191) and Sōtō (by Dōgen, 1227); Zen gains warrior class patronage</td>
+</tr>
+<tr>
+<td>1336-1573</td>
+<td>Muromachi Period</td>
+<td>Zen reaches peak influence; Daitokuji Temple founded in Kyoto; development of tea ceremony, ink painting, and rock gardens</td>
+</tr>
+<tr>
+<td>1467-1477</td>
+<td>Ōnin War</td>
+<td>Much of Kyoto destroyed including major Zen temples; beginning of Sengoku (Warring States) period</td>
+</tr>
+<tr>
+<td>1477-1573</td>
+<td>Sengoku (Warring States)</td>
+<td>Sakai flourishes as autonomous merchant city; Ikkyū (1394-1481) revolutionizes Zen in Sakai; Sen no Rikyū (1522-1591) perfects tea ceremony</td>
+</tr>
+<tr>
+<td>1573-1603</td>
+<td>Azuchi-Momoyama Period</td>
+<td>Oda Nobunaga and Toyotomi Hideyoshi consolidate power; Sakai loses autonomy but maintains cultural influence</td>
+</tr>
+<tr>
+<td>1603-1868</td>
+<td>Edo Period</td>
+<td>Buddhism controlled by shogunate; Hakuin Ekaku (1686-1768) revitalizes Rinzai Zen; most modern Rinzai lineages trace back to him</td>
+</tr>
+<tr>
+<td>1868-1912</td>
+<td>Meiji Period</td>
+<td>Forced separation of Buddhism and Shinto; Buddhism faces persecution but adapts to modernization</td>
+</tr>
+<tr>
+<td>1912-Present</td>
+<td>Modern Era</td>
+<td>Zen spreads globally; today 5.3 million Japanese practice Zen Buddhism, making it Japan's fourth-largest Buddhist denomination</td>
+</tr>
+</tbody>
+</table>
+
+<h2>Sakai: A Haven for Free-Thinking Zen</h2>
+
+<p>During the turbulent Sengoku period (1477-1573), when warfare ravaged much of Japan, Sakai emerged as a prosperous autonomous merchant republic—often compared to Venice. Unlike other Japanese cities controlled by feudal lords, Sakai was governed by an oligarchy of wealthy merchants (egōshū) who valued freedom, commerce, and cultural sophistication.</p>
+
+<p>This atmosphere of independence attracted some of the most unconventional thinkers of the age. The famous Zen priest Ikkyū Sōjun (1394-1481) specifically chose to live in Sakai because of its "free atmosphere"—a stark contrast to the rigid hierarchies of traditional temple Buddhism.</p>
+
+<h3>Ikkyū: The Rebellious Zen Master</h3>
+
+<div class="highlight">
+<strong>Ikkyū's Legacy</strong><br>
+Ikkyū remains one of Japan's most beloved Buddhist figures. A children's anime about him aired 296 episodes (1975-1982) and remains culturally influential today, portraying him as a clever young monk who used wit to solve problems.
+</div>
+
+<p>Ikkyū Sōjun was an extraordinary figure who revolutionized how Zen Buddhism was practiced and understood. Born with imperial blood (possibly the son of Emperor Go-Komatsu), he rejected conventional religious authority and spent much of his life in Sakai, where he could live according to his own principles.</p>
+
+<p><strong>Ikkyū's revolutionary approach:</strong></p>
+<ul>
+<li><strong>Rejected formal certification:</strong> He famously despised the inka system (official certification of enlightenment), calling certified priests "wooden swords"—handsome but useless</li>
+<li><strong>Lived among merchants:</strong> Rather than staying in temples, he walked Sakai's streets in monk's robes carrying a long red wooden sword to symbolize fake religious authority</li>
+<li><strong>Taught practical Zen:</strong> He believed enlightenment came through genuine practice, not certificates or positions</li>
+<li><strong>Embraced contradictions:</strong> Known for visiting sake houses and writing erotic poetry while maintaining deep spiritual practice</li>
+<li><strong>Built bridges between classes:</strong> Extended Zen teachings from warrior elites to merchants and common people</li>
+</ul>
+
+<p>Despite his iconoclasm, when Daitokuji Temple in Kyoto burned during the Ōnin War (1467-1477), the 85-year-old Ikkyū accepted the position of abbot to help rebuild it—enlisting wealthy Sakai merchants he had befriended to fund the reconstruction. This demonstrated his genuine care for Zen tradition even while criticizing its corruptions.</p>
+
+<h2>Sen no Rikyū and the Zen-Tea Connection</h2>
+
+<p>Another Sakai native who profoundly influenced Zen culture was Sen no Rikyū (1522-1591), a merchant's son who became history's greatest tea ceremony master. The tea ceremony (chanoyu) and Zen Buddhism are inseparably linked—both emphasize simplicity, mindfulness, and finding beauty in imperfection.</p>
+
+<p>Rikyū revolutionized tea ceremony by introducing the concept of wabi-sabi (beauty in simplicity and imperfection). He stripped away elaborate displays of wealth, creating intimate tea rooms where social hierarchies dissolved and participants could experience Zen principles of equality and mindfulness.</p>
+
+<p><strong>Zen principles in Rikyū's tea ceremony:</strong></p>
+<ul>
+<li><strong>Wa (harmony):</strong> Unity between host, guests, utensils, and space</li>
+<li><strong>Kei (respect):</strong> Mutual respect regardless of social status</li>
+<li><strong>Sei (purity):</strong> Physical and spiritual cleanliness</li>
+<li><strong>Jaku (tranquility):</strong> Inner peace achieved through mindful practice</li>
+</ul>
+
+<p>Today, you can visit the Sakai Plaza of Rikyu and Akiko to experience authentic tea ceremony and learn about this profound connection between Zen philosophy and daily practice.</p>
+
+<h2>Osaka's Zen Heritage</h2>
+
+<p>While Sakai nurtured revolutionary Zen thinkers, Osaka itself developed important temple complexes and maintained connections to broader Zen networks. The close relationship between tea ceremony culture and Zen Buddhism meant that Osaka's merchant class—like Sakai's—became important patrons of Zen arts including:</p>
+
+<ul>
+<li><strong>Tea ceremony:</strong> Zen-influenced ritual emphasizing mindfulness</li>
+<li><strong>Calligraphy:</strong> Meditative practice of brush painting</li>
+<li><strong>Ikebana (flower arranging):</strong> Zen principles of simplicity and harmony</li>
+<li><strong>Garden design:</strong> Rock gardens (karesansui) representing Zen concepts</li>
+<li><strong>Martial arts:</strong> Integration of Zen meditation with physical training</li>
+</ul>
+
+<h2>Two Main Zen Schools</h2>
+
+<p>Japanese Zen developed into three main schools, two of which remain prominent today:</p>
+
+<p><strong>Rinzai Zen:</strong> Emphasizes kōan practice—riddles and paradoxes that cannot be solved through logical thinking, forcing practitioners to transcend dualistic thinking. Ikkyū belonged to the Rinzai tradition. This school attracted samurai warriors and influenced martial arts.</p>
+
+<p><strong>Sōtō Zen:</strong> Emphasizes shikantaza ("just sitting") meditation without focusing on kōans. Founded by Dōgen (1200-1253), this school teaches that meditation itself is enlightenment rather than a means to achieve it. Today, Sōtō has more followers in Japan than Rinzai.</p>
+
+<h2>Zen's Lasting Impact on Japanese Culture</h2>
+
+<p>Zen Buddhism profoundly shaped Japanese aesthetics and daily life far beyond temple walls. The emphasis on direct experience, simplicity, and finding beauty in imperfection influenced:</p>
+
+<ul>
+<li><strong>Architecture:</strong> Minimalist design, natural materials, integration with nature</li>
+<li><strong>Food culture:</strong> Shōjin ryōri (Zen vegetarian cuisine) and mindful eating</li>
+<li><strong>Business culture:</strong> Concepts of continuous improvement (kaizen) and attention to detail</li>
+<li><strong>Modern mindfulness:</strong> Zen meditation practices now practiced worldwide</li>
+</ul>
+
+<h2>Experiencing Zen Today</h2>
+
+<p>First-time visitors to Osaka and Sakai can connect with this rich Zen heritage through several accessible experiences:</p>
+
+<ul>
+<li><strong>Tea ceremony at Sakai Plaza of Rikyu and Akiko:</strong> Experience the living tradition Rikyū perfected (¥300 includes tea and sweet)</li>
+<li><strong>Visit Zen temples:</strong> Sumiyoshi Taisha (easily accessible from Sakai) showcases ancient Japanese religious architecture</li>
+<li><strong>Explore Zen arts:</strong> Traditional knife-making in Sakai embodies Zen principles of focused craftsmanship</li>
+<li><strong>Mindful walking:</strong> The paths around Daisen Kofun offer opportunities for walking meditation</li>
+</ul>
+
+<div class="highlight">
+<strong>Modern Relevance</strong><br>
+Studies show Zen meditation helps reduce stress and anxiety, improve sleep, and enhance focus—making these ancient practices remarkably relevant for modern life. Many temples in Japan offer zazen (seated meditation) sessions for visitors, typically lasting 15-45 minutes.
+</div>
+
+<h2>Why Sakai's Zen Legacy Matters</h2>
+
+<p>Sakai's unique contribution to Zen Buddhism demonstrates how spiritual traditions evolve through cultural exchange. The merchant city's emphasis on freedom and pragmatism allowed Zen to break free from elite temple bureaucracy and become accessible to common people. Ikkyū's rebellious authenticity and Rikyū's democratizing tea ceremony both emerged from Sakai's distinctive culture—showing how geography and social conditions shape religious expression.</p>
+
+<p>For modern visitors, understanding this history enriches the experience of Sakai's cultural attractions. The knife-making craftsmanship, tea ceremony tradition, and even the city's unpretentious atmosphere all reflect values that Zen Buddhism helped cultivate over centuries.</p>
+
+<div class="wikipedia-link">
+<a href="https://www.japan.travel/en/guide/meditation/" target="_blank">Learn more about Zen meditation experiences in Japan →</a>
+</div>
+
+<div class="navigation">
+<a class="nav-link" data-passage="Ridesharing">← Ridesharing</a>
+<a class="nav-link" data-passage="general1">Back to General Overview →</a>
+</div>
+</div>

--- a/stories/all1/assets/scripts.js
+++ b/stories/all1/assets/scripts.js
@@ -1,0 +1,19 @@
+function toggleLocation(locationId) {
+    const content = document.getElementById(locationId);
+    const iconId = locationId.replace('location', 'icon');
+    const icon = document.getElementById(iconId);
+    
+    if (content && icon) {
+        if (content.classList.contains('expanded')) {
+            // Collapse
+            content.classList.remove('expanded');
+            icon.textContent = '+';
+            icon.style.transform = 'rotate(0deg)';
+        } else {
+            // Expand
+            content.classList.add('expanded');
+            icon.textContent = '−';
+            icon.style.transform = 'rotate(180deg)';
+        }
+    }
+}

--- a/stories/all1/assets/styles.css
+++ b/stories/all1/assets/styles.css
@@ -1,0 +1,495 @@
+body {
+    font-family: 'Georgia', serif !important;
+    background: linear-gradient(135deg, #f0f8ff 0%, #e6f3ff 100%);
+    margin: 0;
+    padding: 4px 10px 10px 10px;
+    min-height: 100vh;
+    line-height: 1.4 !important;
+}
+
+/* AGGRESSIVE RESET - Override SugarCube defaults */
+#passages, #passages *, tw-passage, tw-passage * {
+    margin: 0 !important;
+    padding: 0 !important;
+}
+
+/* Main passage container */
+#passages {
+    max-width: 800px !important;
+    margin: 0 auto !important;
+    background: white !important;
+    padding: 40px 50px !important;
+    border-radius: 15px !important;
+    box-shadow: 0 10px 30px rgba(0,0,0,0.2) !important;
+}
+
+/* Main title colors - simple approach */
+h1, #passages h1, tw-passage h1, .passage h1 {
+    color: #1e3a8a !important;
+    font-size: 2.5em !important;
+    text-align: center !important;
+    margin: 0 0 10px 0 !important;
+    padding: 0 !important;
+    text-indent: 0 !important;
+}
+
+h2, #passages h2, tw-passage h2, .passage h2 {
+    color: #1e3a8a !important;
+    font-size: 1.5em !important;
+    margin: 20px 0 10px 0 !important;
+    padding: 0 0 8px 0 !important;
+    border-bottom: none solid #1e3a8a !important;
+    border-top: none !important;
+    text-indent: 0 !important;
+    text-align: left !important;
+}
+
+h3, #passages h3, tw-passage h3, .passage h3 {
+    color: #2E8B57 !important;
+    margin: 0 0 10px 0 !important;
+    padding: 0 !important;
+    font-size: 1.3em !important;
+    text-indent: 0 !important;
+}
+
+p, #passages p, tw-passage p, .passage p {
+    margin: 3px 0 !important;
+    padding: 15px !important;
+    line-height: 1.4 !important;
+    text-indent: 0 !important;
+    color: #110d2b;
+}
+
+#passages > *:first-child,
+tw-passage > *:first-child,
+.passage > *:first-child,
+.card > *:first-child {
+    margin-top: 0 !important;
+}
+
+/* Remove any default list styling and indentation */
+ul, ol, li {
+    /* list-style: none !important; */
+    margin: 0 !important;
+    padding: 0 !important;
+    text-indent: 0 !important;
+    color: #110d2b;
+}
+
+/* Ensure no elements have text-indent */
+* {
+    text-indent: 0 !important;
+}
+
+.card {
+    background: white;
+    border-radius: 15px;
+    box-shadow: 0 10px 30px rgba(0,0,0,0.2);
+    max-width: 750px;
+    width: 95%;
+    padding: 40px 55px;
+    display: none;
+    position: relative;
+    border: 3px solid #2E8B57;
+    overflow-y: auto;
+    margin: 20px auto;
+    box-sizing: border-box;
+}
+
+@media (max-width: 768px) {
+    .card, #passages {
+        width: 95% !important;
+        padding: 20px 30px !important;
+        margin: 10px auto !important;
+        border-radius: 10px !important;
+    }
+    
+    h1 {
+        font-size: 2em !important;
+    }
+    
+    h2 {
+        font-size: 1.3em !important;
+    }
+}
+
+.card.active {
+    display: block;
+    animation: fadeIn 0.5s ease-in;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; transform: translateY(20px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+.card-header {
+    border-bottom: 2px solid #2E8B57;
+    margin-bottom: 15px !important;
+    padding-bottom: 10px !important;
+}
+
+.card-title {
+    font-size: 2.2em !important;
+    color: #2E8B57 !important;
+    margin: 0 0 5px 0 !important;
+    padding: 0 !important;
+    text-align: center !important;
+    border: none !important;
+}
+
+.card-subtitle {
+    font-size: 1.1em !important;
+    color: #666 !important;
+    text-align: center !important;
+    font-style: italic !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    border: none !important;
+}
+
+.card-content {
+    line-height: 1.4 !important;
+    color: #333 !important;
+    margin-bottom: 30px !important;
+    padding: 0 !important;
+}
+
+.temple-image {
+    width: 100%;
+    height: 250px;
+    object-fit: cover;
+    border-radius: 10px;
+    margin: 15px 0 !important;
+    padding: 0 !important;
+    box-shadow: 0 5px 15px rgba(0,0,0,0.3);
+}
+
+.highlight {
+    background-color: #1e3a8a !important;
+    color: white !important;
+    padding: 20px !important;
+    border-radius: 8px !important;
+    border-left: 4px solid #3b82f6 !important;
+    margin: 20px 0 !important;
+    border: 20px 0 !important;
+    font-style: italic !important;
+    font-weight: 500 !important;
+}
+
+/* Collapsible Location Styles */
+.location-section {
+    background-color: #e8f4fd;
+    border: 2px solid #bee5eb;
+    border-radius: 10px;
+    margin: 20px 0;
+
+}
+
+.location-toggle {
+    padding: 6px 12px !important;
+    margin: 0 !important;
+    cursor: pointer;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    transition: all 0.3s ease;
+    user-select: none;
+}
+
+.location-toggle:hover {
+    background-color: #d1ecf1;
+    border-radius: 8px;
+}
+
+.location-label {
+    color: #0c5460 !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    font-size: 1.05em !important;
+    font-weight: bold !important;
+    display: flex;
+    align-items: margin-left;
+    gap: 8px;
+}
+
+.toggle-icon {
+    color: #0c5460 !important;
+    font-size: 1.2em !important;
+    font-weight: bold !important;
+    transition: transform 0.3s ease;
+    min-width: 20px !important;
+    text-align: center !important;
+    display: block !important;
+    visibility: visible !important;
+    flex-shrink: 0 !important;
+}
+
+.location-content {
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height 0.3s ease, padding 0.3s ease;
+}
+
+.location-content.expanded {
+    max-height: 300px;
+    padding: 0 20px 20px;
+}
+
+.address {
+    margin-bottom: 8px !important;
+    padding: 0 !important;
+    line-height: 1.4 !important;
+}
+
+.address-label {
+    font-weight: bold !important;
+    color: #0c5460 !important;
+    display: inline-block;
+    min-width: 80px;
+}
+
+.address-text {
+    font-family: monospace !important;
+    background: white !important;
+    padding: 4px 8px !important;
+    border-radius: 4px !important;
+    margin-left: 10px !important;
+}
+
+
+.maps-link:hover {
+    background: #3367d6 !important;
+    transform: translateY(-2px);
+    box-shadow: 0 5px 15px rgba(66,133,244,0.3);
+}
+
+.wikipedia-link:hover {
+    background: #0052a3 !important;
+    transform: translateY(-2px);
+    box-shadow: 0 5px 15px rgba(0,102,204,0.3);
+}
+
+.navigation {
+    display: flex !important;
+    justify-content: space-around !important;
+    flex-wrap: wrap !important;
+    gap: 10px !important;
+    border: 20px 0 !important;
+    margin-top: 20px !important;
+    padding-top: 15px !important;
+    border-top: 1px solid #ddd !important;
+}
+
+@media (max-width: 768px) {
+    .navigation {
+        flex-direction: column !important;
+        gap: 15px !important;
+    }
+}
+
+.nav-link, .wikipedia-link, .maps-link  {
+    background: #2E8B57 !important;
+    color: white !important;
+    text-decoration: none !important;
+    padding: 20px 40px !important;
+    border-radius: 35px !important;
+    font-weight: bold !important;
+    transition: all 0.3s ease;
+    text-align: center !important;
+    min-width: 150px !important;
+    cursor: pointer;
+    display: block !important;
+}
+
+.nav-link:hover {
+    background: #228B22 !important;
+    transform: translateY(-2px);
+    box-shadow: 0 5px 15px rgba(0,0,0,0.2);
+}
+
+.card-number {
+    position: absolute;
+    top: 10px;
+    right: 15px;
+    background: #2E8B57 !important;
+    color: white !important;
+    width: 30px;
+    height: 30px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: bold !important;
+}
+
+.toc-grid {
+    display: grid !important;
+    gap: 15px !important;
+    margin: 20px 0 !important;
+    padding: 0 !important;
+}
+
+.toc-item {
+    border: 2px solid #2E8B57 !important;
+    border-radius: 10px !important;
+    padding: 15px !important;
+    margin: 0 !important;
+    transition: all 0.3s ease;
+    background: white !important;
+    display: block !important;
+}
+
+.toc-item:hover {
+    background-color: #f0f8ff !important;
+    transform: translateY(-2px);
+    box-shadow: 0 5px 15px rgba(0,0,0,0.1);
+}
+
+.toc-item h3 {
+    color: #2E8B57 !important;
+    margin: 0 0 10px 0 !important;
+    padding: 0 !important;
+    font-size: 1.3em !important;
+}
+
+.toc-item h3 a {
+    text-decoration: none !important;
+    color: inherit !important;
+}
+
+.toc-item p {
+    margin: 0 !important;
+    padding: 0 !important;
+    color: #666 !important;
+}
+
+/* Hide Twine UI sidebar */
+#ui-bar {
+    display: none !important;
+}
+
+/* Clean link styling */
+a {
+    text-decoration: none !important;
+}
+
+/* FINAL OVERRIDE - Must be at the end to beat SugarCube defaults */
+/* Target specific SugarCube color variables and elements */
+:root {
+    --primary-color: #1e3a8a !important;
+    --header-color: #1e3a8a !important;
+}
+
+/* Override SugarCube's passage rendering */
+tw-passage h1,
+tw-passage h2,
+tw-story h1,
+tw-story h2,
+html tw-passage h1,
+html tw-passage h2 {
+    color: #1e3a8a !important;
+    text-indent: 0 !important;
+    margin-left: 0 !important;
+    padding-left: 0 !important;
+}
+
+/* Target the actual rendered passage content */
+[data-passage="Table of Contents"] h1,
+[data-passage="Table of Contents"] h2,
+.passage h1,
+.passage h2 {
+    color: #1e3a8a !important;
+    text-indent: 0 !important;
+    margin-left: 0 !important;
+    padding-left: 0 !important;
+}
+
+/* Force override any SugarCube theme colors */
+#story h1, #story h2, #story h3,
+#passages h1, #passages h2, #passages h3 {
+    color: #1e3a8a !important;
+    text-indent: 0 !important;
+    margin-left: 0 !important;
+    padding-left: 0 !important;
+}
+
+/* Specific override for "Osaka City Guide" title */
+h1:contains("Osaka City Guide"),
+h1:contains("大阪"),
+[data-passage="Table of Contents"] > h1:first-of-type {
+    color: #1e3a8a !important;
+    text-indent: 0 !important;
+    margin-left: 0 !important;
+    padding-left: 0 !important;
+}
+
+/* CRITICAL: Remove all default spacing and indentation from SugarCube */
+#passages > *, tw-passage > *, .passage > * {
+    text-indent: 0 !important;
+    margin-left: 0 !important;
+    padding-left: 0 !important;
+}
+
+/* Exception: Don't override location toggle colors */
+.location-toggle *, .location-label *, .toggle-icon {
+    color: inherit !important;
+}
+
+/* Ensure no automatic paragraph spacing */
+#passages p + p, tw-passage p + p, .passage p + p {
+    margin-top: 3px !important;
+}
+
+/* Override any default browser/SugarCube margins */
+body, html {
+    margin: 0 !important;
+    padding: 0 !important;
+}
+
+/* Force consistent spacing throughout */
+#passages * {
+    box-sizing: border-box !important;
+}
+
+.footer {
+  font-size: 0.8em;
+  text-align: center;
+  color: #666;
+}
+
+br {
+  line-height: 1px;
+}
+
+/* Info table styling for historical timelines and data tables */
+.info-table, table {
+    width: 100% !important;
+    border-collapse: collapse !important;
+    margin: 20px 0 !important;
+    background: white !important;
+}
+
+.info-table th, table th {
+    background-color: #1e3a8a !important;
+    color: white !important;
+    padding: 12px !important;
+    text-align: left !important;
+    font-weight: bold !important;
+    border: 1px solid #ddd !important;
+}
+
+.info-table td, table td {
+    padding: 10px 12px !important;
+    border: 1px solid #ddd !important;
+    color: #333 !important;
+    line-height: 1.4 !important;
+}
+
+.info-table tr:nth-child(even), table tbody tr:nth-child(even) {
+    background-color: #f8f9fa !important;
+}
+
+.info-table tr:hover, table tbody tr:hover {
+    background-color: #e8f4fd !important;
+}


### PR DESCRIPTION
## Summary
- add the new all1 deck with metadata that loads shared styling and scripts
- build a general1 table of contents that groups Logistics and History sections
- copy the Package Transfers, Ridesharing, and Zen in Sakai and Osaka cards with updated navigation for the new deck

## Testing
- bash scripts/build.sh

------
https://chatgpt.com/codex/tasks/task_e_68de85def64c8330817c631aa1f31a34