### PR TITLE
Fix kyoto1 moon viewing and bamboo night location sections

### DIFF
--- a/stories/kyoto1/01_passages/bamboo-night.twee
+++ b/stories/kyoto1/01_passages/bamboo-night.twee
@@ -40,12 +40,20 @@
   <p>Restrooms are available at the grove exit and near the Randen station; lines are shortest just after opening. Food stalls stay outside the paid zone to protect the forest—eat before or after you walk. If you are returning to Kyoto Station after 20:30, head straight to JR Saga-Arashiyama; the final trains toward Kyoto depart around 23:00, but platforms can be crowded after closing. Ride-hailing supply in Arashiyama dips late at night, so schedule a taxi pickup in advance if you plan to stay for drinks along the Katsura River.</p>
 
   <div class="location-section">
-    <button class="location-toggle" onclick="toggleLocation(this)">Show access details</button>
-    <div class="location-details">
-      <strong>Arashiyama Bamboo Grove Entrance</strong><br>
-      20-2 Sagatenryuji Susukinobaba-cho, Ukyo Ward, Kyoto 616-8384<br>
-      京都府京都市右京区嵯峨天龍寺芒ノ馬場町20-2<br>
-      <a href="https://www.google.com/maps/search/?api=1&query=Arashiyama+Bamboo+Forest" target="_blank" rel="noopener">Open in Google Maps</a>
+    <div class="location-toggle" onclick="toggleLocation('location-bamboo-grove')">
+      <div class="location-label">📍 Location: Arashiyama Bamboo Grove Entrance</div>
+      <div class="toggle-icon" id="icon-bamboo-grove">+</div>
+    </div>
+    <div class="location-content" id="location-bamboo-grove">
+      <div class="address">
+        <span class="address-label">English:</span>
+        <span class="address-text">20-2 Sagatenryuji Susukinobaba-chō, Ukyo Ward, Kyoto 616-8384</span>
+      </div>
+      <div class="address">
+        <span class="address-label">Japanese:</span>
+        <span class="address-text">〒616-8384 京都府京都市右京区嵯峨天龍寺芒ノ馬場町20-2</span>
+      </div>
+      <a href="https://www.google.com/maps/search/?api=1&query=Arashiyama+Bamboo+Forest" target="_blank" class="maps-link">🗺️ Open in Google Maps</a>
     </div>
   </div>
 

--- a/stories/kyoto1/01_passages/moon-viewing.twee
+++ b/stories/kyoto1/01_passages/moon-viewing.twee
@@ -54,7 +54,7 @@
 
   <div class="location-section">
     <div class="location-toggle" onclick="toggleLocation('location-chishakuin')">
-      <div class="location-label">📍 Chishaku-in Temple</div>
+      <div class="location-label">📍 Location: Chishaku-in Temple</div>
       <div class="toggle-icon" id="icon-chishakuin">+</div>
     </div>
     <div class="location-content" id="location-chishakuin">
@@ -72,7 +72,7 @@
 
   <div class="location-section">
     <div class="location-toggle" onclick="toggleLocation('location-taizoin')">
-      <div class="location-label">📍 Myōshin-ji Taizō-in</div>
+      <div class="location-label">📍 Location: Myōshin-ji Taizō-in</div>
       <div class="toggle-icon" id="icon-taizoin">+</div>
     </div>
     <div class="location-content" id="location-taizoin">
@@ -90,7 +90,7 @@
 
   <div class="location-section">
     <div class="location-toggle" onclick="toggleLocation('location-daikakuji')">
-      <div class="location-label">📍 Daikaku-ji & Ōsawa Pond</div>
+      <div class="location-label">📍 Location: Daikaku-ji & Ōsawa Pond</div>
       <div class="toggle-icon" id="icon-daikakuji">+</div>
     </div>
     <div class="location-content" id="location-daikakuji">
@@ -108,7 +108,7 @@
 
   <div class="location-section">
     <div class="location-toggle" onclick="toggleLocation('location-shimogamo')">
-      <div class="location-label">📍 Shimogamo-jinja</div>
+      <div class="location-label">📍 Location: Shimogamo-jinja</div>
       <div class="toggle-icon" id="icon-shimogamo">+</div>
     </div>
     <div class="location-content" id="location-shimogamo">
@@ -126,7 +126,7 @@
 
   <div class="location-section">
     <div class="location-toggle" onclick="toggleLocation('location-kamigamo')">
-      <div class="location-label">📍 Kamigamo-jinja</div>
+      <div class="location-label">📍 Location: Kamigamo-jinja</div>
       <div class="toggle-icon" id="icon-kamigamo">+</div>
     </div>
     <div class="location-content" id="location-kamigamo">
@@ -144,7 +144,7 @@
 
   <div class="location-section">
     <div class="location-toggle" onclick="toggleLocation('location-hirano')">
-      <div class="location-label">📍 Hirano-jinja</div>
+      <div class="location-label">📍 Location: Hirano-jinja</div>
       <div class="toggle-icon" id="icon-hirano">+</div>
     </div>
     <div class="location-content" id="location-hirano">
@@ -162,7 +162,7 @@
 
   <div class="location-section">
     <div class="location-toggle" onclick="toggleLocation('location-yasaka')">
-      <div class="location-label">📍 Yasaka-jinja (Gion)</div>
+      <div class="location-label">📍 Location: Yasaka-jinja (Gion)</div>
       <div class="toggle-icon" id="icon-yasaka">+</div>
     </div>
     <div class="location-content" id="location-yasaka">
@@ -180,7 +180,7 @@
 
   <div class="location-section">
     <div class="location-toggle" onclick="toggleLocation('location-matsunoo')">
-      <div class="location-label">📍 Matsunoo-taisha</div>
+      <div class="location-label">📍 Location: Matsunoo-taisha</div>
       <div class="toggle-icon" id="icon-matsunoo">+</div>
     </div>
     <div class="location-content" id="location-matsunoo">

--- a/stories/kyoto1/assets/styles.css
+++ b/stories/kyoto1/assets/styles.css
@@ -255,6 +255,7 @@ ul, ol, li {
     padding: 4px 8px !important;
     border-radius: 4px !important;
     margin-left: 10px !important;
+    color: #0c5460 !important;
 }
 
 


### PR DESCRIPTION
## Summary
- add "Location:" headings to each moon viewing entry so the toggle labels match other cards
- replace bamboo night access details with the shared collapsible location block pattern
- darken kyoto1 address text styling for better contrast in every location block

## Testing
- ./scripts/build.sh

------
https://chatgpt.com/codex/tasks/task_e_68df93a43f4c8330ad09c94507975c50